### PR TITLE
x86: Add Keyboard support for i8042 controller

### DIFF
--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -13,10 +13,10 @@ use x86::registers::bits32::paging::{PD, PT};
 use x86::support;
 use x86::{Boundary, InterruptPoller};
 
+use crate::keyboard::Keyboard;
 use crate::pit::{Pit, RELOAD_1KHZ};
 use crate::serial::{SerialPort, SerialPortComponent, COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE};
 use crate::vga_uart_driver::VgaText;
-use crate::keyboard::Keyboard;
 
 /// Interrupt constants for legacy PC peripherals
 mod interrupt {

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -301,6 +301,12 @@ impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
         // connect keyboard as the ps/2 client, controller will call `receive_scancode`
         ps2.set_client(keyboard);
         keyboard.init_device();
+
+        // allow IRQ1 to fire
+        unsafe {
+            crate::pic::unmask(interrupt::KEYBOARD);
+        }
+
         let pc = s.4.write(Pc {
             com1,
             com2,

--- a/chips/x86_q35/src/chip.rs
+++ b/chips/x86_q35/src/chip.rs
@@ -6,7 +6,7 @@ use core::fmt::Write;
 use core::mem::MaybeUninit;
 
 use kernel::component::Component;
-use kernel::platform::chip::Chip;
+use kernel::platform::chip::{Chip, InterruptService};
 use kernel::static_init;
 use x86::mpu::PagingMPU;
 use x86::registers::bits32::paging::{PD, PT};
@@ -14,6 +14,7 @@ use x86::support;
 use x86::{Boundary, InterruptPoller};
 
 use crate::keyboard::Keyboard;
+use crate::pic::PIC1_OFFSET;
 use crate::pit::{Pit, RELOAD_1KHZ};
 use crate::serial::{SerialPort, SerialPortComponent, COM1_BASE, COM2_BASE, COM3_BASE, COM4_BASE};
 use crate::vga_uart_driver::VgaText;
@@ -43,7 +44,23 @@ mod interrupt {
 /// chip definition should be broadly compatible with most PC hardware.
 ///
 /// Parameter `PR` is the PIT reload value. See [`Pit`] for more information.
-pub struct Pc<'a, const PR: u16 = RELOAD_1KHZ> {
+///
+/// # Interrupt Handling
+///
+/// This chip automatically handles interrupts for legacy PC devices which are known to be present
+/// on QEMU's Q35 machine type. This includes the PIT timer and four serial ports. Other devices
+/// which are conditionally present (e.g. Virtio devices specified on the QEMU command line) may be
+/// handled via a board-specific implementation of [`InterruptService`].
+///
+/// This chip uses the legacy 8259 PIC to manage interrupts. This is relatively simple compared with
+/// using the Local APIC or I/O APIC and avoids needing to interact with ACPI or MP tables.
+///
+/// Internally, this chip re-maps the PIC interrupt numbers to avoid conflicts with ISA-defined
+/// exceptions. This remapping is fully encapsulated within the chip. **N.B.** Implementors of
+/// [`InterruptService`] will be passed the physical interrupt line number, _not_ the remapped
+/// number used internally by the chip. This should match the interrupt line number reported by
+/// documentation or read from the PCI configuration space.
+pub struct Pc<'a, I: InterruptService + 'a, const PR: u16 = RELOAD_1KHZ> {
     /// Legacy COM1 serial port
     pub com1: &'a SerialPort<'a>,
 
@@ -71,9 +88,14 @@ pub struct Pc<'a, const PR: u16 = RELOAD_1KHZ> {
     /// System call context
     syscall: Boundary,
     paging: PagingMPU<'a>,
+
+    /// Board-provided interrupt service for handling non-core IRQs (e.g., PCI devices)
+    int_svc: &'a I,
 }
 
-impl<'a, const PR: u16> Chip for Pc<'a, PR> {
+impl<'a, I: InterruptService + 'a, const PR: u16> Chip for Pc<'a, I, PR> {
+    type ThreadIdProvider = x86::thread_id::X86ThreadIdProvider;
+
     type MPU = PagingMPU<'a>;
     fn mpu(&self) -> &Self::MPU {
         &self.paging
@@ -87,6 +109,7 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
     fn service_pending_interrupts(&self) {
         InterruptPoller::access(|poller| {
             while let Some(num) = poller.next_pending() {
+                let mut handled = true;
                 match num {
                     interrupt::PIT => self.pit.handle_interrupt(),
                     interrupt::COM2_COM4 => {
@@ -97,16 +120,27 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
                         self.com1.handle_interrupt();
                         self.com3.handle_interrupt();
                     }
-
-                    // new PS/2 keyboard interrupt handler
                     interrupt::KEYBOARD => {
                         self.ps2.handle_interrupt();
                     }
-
-                    _ => unimplemented!("interrupt {num}"),
+                    _ => {
+                        // Convert back to physical interrupt line number before passing to
+                        // board-specific handler
+                        let phys_num = num - PIC1_OFFSET as u32;
+                        handled = unsafe { self.int_svc.service_interrupt(phys_num) };
+                    }
                 }
 
                 poller.clear_pending(num);
+
+                // Unmask the interrupt so it can fire again, but only if we know how to handle it
+                if handled {
+                    unsafe {
+                        crate::pic::unmask(num);
+                    }
+                } else {
+                    kernel::debug!("Unhandled external interrupt {} left masked", num);
+                }
             }
         })
     }
@@ -180,12 +214,13 @@ impl<'a, const PR: u16> Chip for Pc<'a, PR> {
 /// During the call to `finalize()`, this helper will perform low-level initialization of the PC
 /// hardware to ensure a consistent CPU state. This includes initializing memory segmentation and
 /// interrupt handling. See [`x86::init`] for further details.
-pub struct PcComponent<'a> {
+pub struct PcComponent<'a, I: InterruptService + 'a> {
     pd: &'a mut PD,
     pt: &'a mut PT,
+    int_svc: &'a I,
 }
 
-impl<'a> PcComponent<'a> {
+impl<'a, I: InterruptService + 'a> PcComponent<'a, I> {
     /// Creates a new `PcComponent` instance.
     ///
     /// ## Safety
@@ -197,21 +232,21 @@ impl<'a> PcComponent<'a> {
     /// will cause the kernel's code/data to move unexpectedly.
     ///
     /// See [`x86::init`] for further details.
-    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT) -> Self {
-        Self { pd, pt }
+    pub unsafe fn new(pd: &'a mut PD, pt: &'a mut PT, int_svc: &'a I) -> Self {
+        Self { pd, pt, int_svc }
     }
 }
 
-impl Component for PcComponent<'static> {
+impl<I: InterruptService + 'static> Component for PcComponent<'static, I> {
     type StaticInput = (
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
         <SerialPortComponent as Component>::StaticInput,
-        &'static mut MaybeUninit<Pc<'static>>,
+        &'static mut MaybeUninit<Pc<'static, I>>,
         &'static mut MaybeUninit<crate::keyboard::Keyboard<'static>>,
     );
-    type Output = &'static Pc<'static>;
+    type Output = &'static Pc<'static, I>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         // Low-level hardware initialization. We do this first to guarantee the CPU is in a
@@ -277,6 +312,7 @@ impl Component for PcComponent<'static> {
             keyboard,
             syscall,
             paging,
+            int_svc: self.int_svc,
         });
 
         pc
@@ -286,13 +322,13 @@ impl Component for PcComponent<'static> {
 /// Provides static buffers needed for `PcComponent::finalize()`.
 #[macro_export]
 macro_rules! x86_q35_component_static {
-    () => {{
+    ($isr_ty:ty) => {{
         (
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
             $crate::serial_port_component_static!(),
-            kernel::static_buf!($crate::Pc<'static>),
+            kernel::static_buf!($crate::Pc<'static, $isr_ty>),
             kernel::static_buf!($crate::keyboard::Keyboard<'static>),
         )
     };};

--- a/chips/x86_q35/src/cmd_fifo.rs
+++ b/chips/x86_q35/src/cmd_fifo.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! Minimal, non-alloc ring FIFO for small fixed-size queues.
+
+// Why `FifoItem::EMPTY` and const init?
+// We need to create the FIFO in static memory (no heap). That means the backing
+// array `[T; N]` must be initialized in a `const` context. I believe we can't  directly
+// call `T::default()` in `const fn`, so `[T::default(); N]` won’t work.
+// By requiring `T: FifoItem` with a `const EMPTY`, we can do `[T::EMPTY; N]`
+// and safely build the FIFO at compile time
+
+pub(crate) trait FifoItem: Copy {
+    /// Const zero/empty value used to initialize the backing array.
+    const EMPTY: Self;
+}
+
+pub(crate) struct Fifo<T: FifoItem, const N: usize> {
+    buf: [T; N],
+    head: usize,
+    tail: usize,
+    len: usize,
+}
+
+impl<T: FifoItem, const N: usize> Fifo<T, N> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            buf: [T::EMPTY; N],
+            head: 0,
+            tail: 0,
+            len: 0,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+    #[inline]
+    pub(crate) fn is_full(&self) -> bool {
+        self.len == N
+    }
+    #[inline]
+    pub(crate) fn push(&mut self, item: T) -> Result<(), ()> {
+        if self.is_full() {
+            return Err(());
+        }
+        self.buf[self.head] = item;
+        self.head = (self.head + 1) % N;
+        self.len += 1;
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn peek(&self) -> Option<&T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(&self.buf[self.tail])
+        }
+    }
+
+    #[inline]
+    pub(crate) fn peek_mut(&mut self) -> Option<&mut T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(&mut self.buf[self.tail])
+        }
+    }
+
+    #[inline]
+    pub(crate) fn pop(&mut self) -> Option<T> {
+        if self.is_empty() {
+            return None;
+        }
+        let item = self.buf[self.tail];
+        self.tail = (self.tail + 1) % N;
+        self.len -= 1;
+        Some(item)
+    }
+}

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -8,6 +8,7 @@
 //! - I8042 (ports available on 0X60/0X64) delivers keyboard bytes via IRQ1
 //! - We use scan Code set 2 (no translation). 0xE0/0xE1 are prefixes; 0xF0 marks BREAK
 //! - Keyboard speaks simple command/ACK (0xFA) / RESEND (0xFE) protocol
+//!
 //! References:
 //! - OSDev: i8042 PS/2 Controller — https://wiki.osdev.org/I8042_PS/2_Controller
 //! - OSDev: PS/2 Keyboard — https://wiki.osdev.org/PS/2_Keyboard
@@ -17,7 +18,6 @@ use crate::cmd_fifo::Fifo as CmdFifo;
 use crate::ps2::Ps2Client;
 use crate::ps2::Ps2Controller;
 use core::cell::Cell;
-use kernel::debug;
 use kernel::hil::keyboard::{Keyboard as HilKeyboard, KeyboardClient as HilKeyboardClient};
 use kernel::utilities::cells::OptionalCell;
 
@@ -334,13 +334,13 @@ impl<'a> Keyboard<'a> {
         let breaking = self.got_f0.replace(false);
         let pressed = !breaking;
 
-        // log the final key event (after prefixes are applied)
-        debug!(
-            "ps2kbd: {} {}{:02X}",
-            if pressed { "MAKE " } else { "BREAK" },
-            if extended { "E0 " } else { "" },
-            byte
-        );
+        // // log the final key event (after prefixes are applied)
+        // debug!(
+        // "ps2kbd: {} {}{:02X}",
+        // if pressed { "MAKE " } else { "BREAK" },
+        // if extended { "E0 " } else { "" },
+        // byte
+        // );
 
         // Emit Linux keycode to the HIL client
         if let Some(code) = linux_key_for(extended, byte) {

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -100,13 +100,6 @@ const RESP_ACK: u8 = 0xFA;
 const RESP_RESEND: u8 = 0xFE;
 const RESP_BAT_OK: u8 = 0xAA; // BAT after reset
 
-/// Optional byte send for ASCII output (useful for a later capsule)
-/// Not used by the current ASCII-only console path. Subject to change.
-/// Called from the keyboard's deferred (bottom-half) context; keep it non-blocking.
-pub(crate) trait AsciiClient {
-    fn put_byte(&self, b: u8);
-}
-
 /// We will add a small "command engine" (command/response state machine)
 /// with ACK/RESEND handling.
 /// A fixed-size FIFO holds short command sequences (e.g., F0 02, F4).
@@ -167,7 +160,6 @@ impl Default for CmdEntry {
 pub struct Keyboard<'a> {
     ps2: &'a Ps2Controller,
     client: OptionalCell<&'a dyn HilKeyboardClient>,
-    ascii: OptionalCell<&'static dyn AsciiClient>,
 
     // decoder state
     got_e0: Cell<bool>,   // sau 0xE0: next code is extended
@@ -202,7 +194,6 @@ impl<'a> Keyboard<'a> {
         Self {
             ps2,
             client: OptionalCell::empty(),
-            ascii: OptionalCell::empty(),
 
             // decoder state
             got_e0: Cell::new(false),
@@ -231,112 +222,6 @@ impl<'a> Keyboard<'a> {
     /// This will use the command engine (ACK/RESEND) and can run with IRQ1 enabled.
     pub fn init_device(&self) {
         // TODO
-    }
-
-    /// Not used by the current ASCII-only console path. Subject to change.
-    /// Will expand when writing a capsule for PC
-    #[allow(dead_code)]
-    pub(crate) fn set_ascii_client(&self, c: &'static dyn AsciiClient) {
-        self.ascii.set(c);
-    }
-
-    /// Translate a Set-2 scancode to US-ASCII (press only, non-extended)
-    /// Returns None for unmapped keys
-    /**
-     * ASCII mapping: US layout, press-only, non-extended keys.
-     * Shift + Caps for letters; digits/punct respect Shift.
-     * Enter => '\n', Backspace => 0x08, Tab => '\t'. Extended keypad Enter and arrows return None.
-     */
-    #[inline(always)]
-    fn ascii_for(&self, code: u8, pressed: bool, extended: bool) -> Option<u8> {
-        if !pressed || extended {
-            return None;
-        }
-        // modifier states
-        let shift = self.shift_l.get() || self.shift_r.get();
-        let caps = self.caps.get();
-
-        // letters
-        let letter = match code {
-            0x1C => b'a',
-            0x32 => b'b',
-            0x21 => b'c',
-            0x23 => b'd',
-            0x24 => b'e',
-            0x2B => b'f',
-            0x34 => b'g',
-            0x33 => b'h',
-            0x43 => b'i',
-            0x3B => b'j',
-            0x42 => b'k',
-            0x4B => b'l',
-            0x3A => b'm',
-            0x31 => b'n',
-            0x44 => b'o',
-            0x4D => b'p',
-            0x15 => b'q',
-            0x2D => b'r',
-            0x1B => b's',
-            0x2C => b't',
-            0x3C => b'u',
-            0x2A => b'v',
-            0x1D => b'w',
-            0x22 => b'x',
-            0x35 => b'y',
-            0x1A => b'z',
-            _ => 0,
-        };
-        if letter != 0 {
-            let upper = shift ^ caps;
-            return Some(if upper {
-                letter.to_ascii_uppercase()
-            } else {
-                letter
-            });
-        }
-
-        // Digits
-        let digit = match code {
-            0x16 => (b'1', b'!'),
-            0x1E => (b'2', b'@'),
-            0x26 => (b'3', b'#'),
-            0x25 => (b'4', b'$'),
-            0x2E => (b'5', b'%'),
-            0x36 => (b'6', b'^'),
-            0x3D => (b'7', b'&'),
-            0x3E => (b'8', b'*'),
-            0x46 => (b'9', b'('),
-            0x45 => (b'0', b')'),
-            _ => (0, 0),
-        };
-        if digit.0 != 0 {
-            return Some(if shift { digit.1 } else { digit.0 });
-        }
-
-        // Punctuation / misc (US)
-        let punct = match code {
-            0x0E => (b'`', b'~'),
-            0x4E => (b'-', b'_'),
-            0x55 => (b'=', b'+'),
-            0x54 => (b'[', b'{'),
-            0x5B => (b']', b'}'),
-            0x5D => (b'\\', b'|'),
-            0x4C => (b';', b':'),
-            0x52 => (b'\'', b'"'),
-            0x41 => (b',', b'<'),
-            0x49 => (b'.', b'>'),
-            0x4A => (b'/', b'?'),
-            0x29 => (b' ', b' '),   // space
-            0x0D => (b'\t', b'\t'), // tab
-            0x5A => (b'\n', b'\n'), // enter
-            0x66 => (0x08, 0x08),   // backspace
-            _ => (0, 0),
-        };
-        if punct.0 != 0 {
-            return Some(if shift { punct.1 } else { punct.0 });
-        }
-
-        None
     }
 
     /// Command engine public API
@@ -472,12 +357,6 @@ impl<'a> Keyboard<'a> {
             (SC_RSHIFT, false) => self.shift_r.set(pressed),
             (SC_CAPS, _) if pressed => self.caps.set(!self.caps.get()), // toggle on make; ignore break
             _ => {}
-        }
-
-        if let Some(b) = self.ascii_for(byte, pressed, extended) {
-            if self.ascii.is_some() {
-                self.ascii.map(|c| c.put_byte(b));
-            }
         }
     }
 }

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -6,11 +6,11 @@
 
 #![allow(dead_code)] // ONLY FOR THIS MILESTONE SKELETON, WILL BE REMOVED
 
-use core::cell::Cell;
-use kernel::debug;
-use kernel::utilities::cells::OptionalCell;
 use crate::ps2::Ps2Client;
 use crate::ps2::Ps2Controller;
+use core::cell::{Cell, RefCell};
+use kernel::debug;
+use kernel::utilities::cells::OptionalCell;
 
 // Minimal, layout-free key event (future commits will populate this)
 #[derive(Copy, Clone, Debug)]
@@ -20,13 +20,43 @@ pub struct KeyEvent {
     /// true = make (press), false = break (release)
     pub pressed: bool,
     /// true if the event came via the E0 prefix (extended)
-    pub extended: bool
+    pub extended: bool,
 }
 
 /// Callback that the keyboard will use to deliver events
 pub trait KeyboardClient {
-    fn key_event (&self, _ev: KeyEvent) {
+    fn key_event(&self, _ev: KeyEvent) {
         // TODO
+    }
+}
+
+/// We will add a small "command engine" (command/response state machine)
+/// with ACK/RESEND handling.
+/// A fixed-size FIFO holds short command sequences (e.g., F0 02, F4).
+/// One byte is in flight at a time; 0xFA ACK advances, 0xFE RESEND retries.
+
+const CMDQ_LEN: usize = 8;
+const CMD_MAX_LEN: usize = 3;
+const MAX_RETRIES: u8 = 3; // to not be confused with the deff call "good bytes" we do for telemetry
+
+#[derive(Copy, Clone)]
+struct CmdEntry {
+    bytes: [u8; CMD_MAX_LEN],
+    len: u8,
+    idx: u8, //next byte to send
+}
+
+impl CmdEntry {
+    const fn empty() -> Self {
+        Self {
+            bytes: [0; CMD_MAX_LEN],
+            len: 0,
+            idx: 0,
+        }
+    }
+
+    fn is_done(&self) -> bool {
+        (self.idx as usize) >= (self.len as usize)
     }
 }
 
@@ -37,10 +67,23 @@ pub trait KeyboardClient {
 
 pub struct Keyboard<'a> {
     ps2: &'a Ps2Controller,
-    client: OptionalCell<&'a dyn KeyboardClient>,
+    client: OptionalCell<&'static dyn KeyboardClient>,
 
-    // we only track bytes for now
     bytes_seen: Cell<u32>,
+    // here comes the engine
+    cmd_q: RefCell<[CmdEntry; CMDQ_LEN]>,
+    q_head: Cell<usize>,  // write cursor
+    q_tail: Cell<usize>,  // read cursor
+    q_count: Cell<usize>, // number of entries enqueued
+
+    in_flight: Cell<bool>,  // waiting for ACK/RESEND to the last sent byte
+    retries_left: Cell<u8>, // remaining entries for the current byte
+    // telemetry
+    cmd_sent_bytes: Cell<u32>,  //bytes attempted to send
+    cmd_acks: Cell<u32>,        // ACKs observed
+    cmd_resends: Cell<u32>,     // RESENDs observed
+    cmd_drops: Cell<u32>,       //commands dropped after retry execution
+    cmd_send_errors: Cell<u32>, // controller TX errors/timeouts
 }
 
 impl<'a> Keyboard<'a> {
@@ -49,6 +92,20 @@ impl<'a> Keyboard<'a> {
             ps2,
             client: OptionalCell::empty(),
             bytes_seen: Cell::new(0),
+
+            cmd_q: RefCell::new([CmdEntry::empty(); CMDQ_LEN]),
+            q_head: Cell::new(0),
+            q_tail: Cell::new(0),
+            q_count: Cell::new(0),
+
+            in_flight: Cell::new(false),
+            retries_left: Cell::new(0),
+
+            cmd_sent_bytes: Cell::new(0),
+            cmd_acks: Cell::new(0),
+            cmd_resends: Cell::new(0),
+            cmd_drops: Cell::new(0),
+            cmd_send_errors: Cell::new(0),
         }
     }
 
@@ -62,22 +119,162 @@ impl<'a> Keyboard<'a> {
     pub fn init_device(&self) {
         // TODO
     }
-}
 
-impl<'a> Ps2Client for Keyboard<'a> {
+    /// Command engine public API
+    ///
+    /// Enqueue a short command sequence
+    /// Returns false if the queue is full or seq is too long
+
+    pub fn enqueue_command(&self, seq: &[u8]) -> bool {
+        if seq.is_empty() || seq.len() > CMD_MAX_LEN {
+            return false;
+        }
+        if self.q_count.get() >= CMDQ_LEN {
+            return false;
+        }
+        // Copy into the queue at head
+        let head = self.q_head.get();
+        {
+            let mut q = self.cmd_q.borrow_mut();
+            let e = &mut q[head];
+            e.bytes = [0; CMD_MAX_LEN];
+            e.bytes[..seq.len()].copy_from_slice(seq);
+            e.len = seq.len() as u8;
+            e.idx = 0;
+        }
+        self.q_head.set((head + 1) % CMDQ_LEN);
+        self.q_count.set(self.q_count.get() + 1);
+        self.drive_tx();
+
+        true
+    }
+
+    /// Try to transmit the next byte of the current command
+    fn drive_tx(&self) {
+        if self.in_flight.get() || self.q_count.get() == 0 {
+            return;
+        }
+
+        // Peek current entry at tail and the next byte to send
+        let (byte_opt, done) = {
+            let q = self.cmd_q.borrow();
+            let e = &q[self.q_tail.get()];
+            if e.is_done() {
+                (None, true)
+            } else {
+                (Some(e.bytes[e.idx as usize]), false)
+            }
+        };
+
+        if done {
+            // This shouldn't persist-pop and try again
+            self.pop_cmd();
+            self.drive_tx();
+            return;
+        }
+
+        if let Some(b) = byte_opt {
+            // Attempt to send. If the controller times out, do not mark inflight,
+            // so a later call may retry. We also don't advance idx here, only on ACK
+            match self.ps2.send_port1(b) {
+                Ok(()) => {
+                    self.in_flight.set(true);
+                    if self.retries_left.get() == 0 {
+                        // first attempt for this byte
+                        self.retries_left.set(MAX_RETRIES);
+                    }
+                    self.cmd_sent_bytes
+                        .set(self.cmd_sent_bytes.get().wrapping_add(1));
+                }
+
+                Err(_e) => {
+                    // Controller busy/timeout; count and let a later tick retry
+                    self.cmd_send_errors
+                        .set(self.cmd_send_errors.get().wrapping_add(1));
+                }
+            }
+        }
+    }
+
+    fn pop_cmd(&self) {
+        if self.q_count.get() == 0 {
+            return;
+        }
+        self.q_tail.set((self.q_tail.get() + 1) % CMDQ_LEN);
+        self.q_count.set(self.q_count.get() - 1);
+    }
+
+    fn advance_idx_after_ack(&self) {
+        // Increment idx of the current entry; if complete, pop
+        let mut finished = false;
+        {
+            let mut q = self.cmd_q.borrow_mut();
+            let e = &mut q[self.q_tail.get()];
+            if !e.is_done() {
+                e.idx = e.idx.saturating_add(1)
+            }
+            if e.is_done() {
+                finished = true;
+            }
+        }
+        if finished {
+            self.pop_cmd();
+        }
+
+        // New byte will get a fresh budget retry on first send
+        self.retries_left.set(0);
+    }
+}
+impl Ps2Client for Keyboard<'_> {
     /// Called by the controller (in def context) for each byte)
     fn receive_scancode(&self, byte: u8) {
+        // First, if a command byte is in flight, interpret 0XFA/0XFE
+        if self.in_flight.get() {
+            match byte {
+                0xFA => {
+                    // ACK
+                    self.cmd_acks.set(self.cmd_acks.get().wrapping_add(1));
+                    self.in_flight.set(false);
+                    self.advance_idx_after_ack();
+                    // Immediately try to send the next byte/command
+                    self.drive_tx();
+                    return;
+                }
+                0xFE => {
+                    // RESEND - bounded retry of the same byte
+                    self.cmd_resends.set(self.cmd_resends.get().wrapping_add(1));
+                    let left = self.retries_left.get();
+                    if left > 1 {
+                        self.retries_left.set(left - 1);
+                        self.in_flight.set(false);
+                        self.drive_tx(); // resend same byte, don't reset retries
+                    } else {
+                        // Give up on this command
+                        self.cmd_drops.set(self.cmd_drops.get().wrapping_add(1));
+                        self.in_flight.set(false);
+                        self.pop_cmd();
+                        self.retries_left.set(0); // clear for the next new byte
+                        self.drive_tx();
+                    }
+                    return;
+                }
+                _ => {
+                    // Not an ACK/RESEND. For now we ignore it
+                    // Keep waiting for ACK/RESEND
+                }
+            }
+        }
         // For now: basic init + counter
         let n = self.bytes_seen.get().wrapping_add(1);
         self.bytes_seen.set(n);
 
         // keep the log basic
-        if n<= 8 || (n & 0x0F) == 0 {
+        if n <= 8 || (n & 0x0F) == 0 {
             debug!("ps2-kbd: byte {:02x} (count={})", byte, n);
         }
 
         // Decoder and event emitter come in the future
-        // Do not call the keyboardClient yet
         let _ = &self.ps2;
+        let _ = &self.client;
     }
 }

--- a/chips/x86_q35/src/keyboard.rs
+++ b/chips/x86_q35/src/keyboard.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2025.
+
+//! PS/2 keyboard device skeleton over the i8042 controller.
+
+#![allow(dead_code)] // ONLY FOR THIS MILESTONE SKELETON, WILL BE REMOVED
+
+use core::cell::Cell;
+use kernel::debug;
+use kernel::utilities::cells::OptionalCell;
+use crate::ps2::Ps2Client;
+use crate::ps2::Ps2Controller;
+
+// Minimal, layout-free key event (future commits will populate this)
+#[derive(Copy, Clone, Debug)]
+pub struct KeyEvent {
+    /// Derive key identifier (based on Set-2)
+    pub keycode: u16,
+    /// true = make (press), false = break (release)
+    pub pressed: bool,
+    /// true if the event came via the E0 prefix (extended)
+    pub extended: bool
+}
+
+/// Callback that the keyboard will use to deliver events
+pub trait KeyboardClient {
+    fn key_event (&self, _ev: KeyEvent) {
+        // TODO
+    }
+}
+
+/// We capture bytes and will later add:
+/// 1) Command FIFO with ACK/RESEND handling
+/// 2) Set-2 decoder state machine (e0/f0/e1)
+/// Modifier tracking and ASCII/layout mapping in upper layers
+
+pub struct Keyboard<'a> {
+    ps2: &'a Ps2Controller,
+    client: OptionalCell<&'a dyn KeyboardClient>,
+
+    // we only track bytes for now
+    bytes_seen: Cell<u32>,
+}
+
+impl<'a> Keyboard<'a> {
+    pub const fn new(ps2: &'a Ps2Controller) -> Self {
+        Self {
+            ps2,
+            client: OptionalCell::empty(),
+            bytes_seen: Cell::new(0),
+        }
+    }
+
+    /// Install the client which will receive the events
+    pub fn set_client(&self, client: &'static dyn KeyboardClient) {
+        self.client.set(client);
+    }
+
+    /// Device-level init hook. No-op for now since the `init_early()`
+    /// already is done by the controller
+    pub fn init_device(&self) {
+        // TODO
+    }
+}
+
+impl<'a> Ps2Client for Keyboard<'a> {
+    /// Called by the controller (in def context) for each byte)
+    fn receive_scancode(&self, byte: u8) {
+        // For now: basic init + counter
+        let n = self.bytes_seen.get().wrapping_add(1);
+        self.bytes_seen.set(n);
+
+        // keep the log basic
+        if n<= 8 || (n & 0x0F) == 0 {
+            debug!("ps2-kbd: byte {:02x} (count={})", byte, n);
+        }
+
+        // Decoder and event emitter come in the future
+        // Do not call the keyboardClient yet
+        let _ = &self.ps2;
+    }
+}

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -28,3 +28,4 @@ pub mod serial;
 
 pub mod vga;
 pub mod vga_uart_driver;
+pub mod keyboard;

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -26,6 +26,7 @@ pub mod pit;
 pub mod ps2;
 pub mod serial;
 
+mod cmd_fifo;
 pub mod keyboard;
 pub mod vga;
 pub mod vga_uart_driver;

--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -26,6 +26,6 @@ pub mod pit;
 pub mod ps2;
 pub mod serial;
 
+pub mod keyboard;
 pub mod vga;
 pub mod vga_uart_driver;
-pub mod keyboard;

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -270,7 +270,7 @@ impl Ps2Controller {
 
     /// Send one byte to port 0x60 (device), small runtime spin budget.
     #[inline(always)]
-    pub(crate) fn send_port1(&self, byte: u8) -> Ps2Result<()> {
+    pub(crate) fn send_port1(&self, byte: u8) -> Result<(), Ps2Error> {
         write_data_with(byte, SPINS_RUNTIME)
     }
 

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -272,6 +272,14 @@ impl Ps2Controller {
         }
     }
 
+    /// Send one byte to the keyboard data port (0x60).
+    /// Busy-waits with a small runtime spin budget.
+    /// No ACK/RESEND handling here; that lives in the keyboard.
+    #[inline(always)]
+    pub(crate) fn send_port1(&self, byte: u8) -> Ps2Result<()> {
+        write_data_with(byte, SPINS_RUNTIME)
+    }
+
     /// Install the "keyboard" client, we'll wire calls to this later
     /// for now it's just the hook
     pub fn set_client(&self, client: &'static dyn Ps2Client) {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds driver support for a keyboard device. It implements the client from the PS/2 controller


### Testing Strategy

This pull request was tested by @domnudragota, keyboard can decode button presses + modifiers (no numpad yet)


### TODO or Help Wanted

This pull request will need a capsule when porting the Process Console (?) to VGA. This is just the driver itself.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
