### PR TITLE
[EXPERIMENTAL] x86: Remove static_init from chip crate

### DIFF
--- a/chips/x86_q35/src/lib.rs
+++ b/chips/x86_q35/src/lib.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2024.
+// Copyright Tock Contributors 2025.
 
 //! Support for traditional x86 PC hardware.
 //!
@@ -15,15 +15,13 @@
 #![no_std]
 
 mod chip;
-pub use chip::{Pc, PcComponent};
+pub use chip::Pc;
+pub use chip::{vga_early_clear, x86_low_level_init};
 
 mod interrupts;
-
 mod pic;
 
 pub mod pit;
-
 pub mod serial;
-
 pub mod vga;
 pub mod vga_uart_driver;

--- a/chips/x86_q35/src/vga.rs
+++ b/chips/x86_q35/src/vga.rs
@@ -457,7 +457,7 @@ pub fn framebuffer() -> Option<(*mut u8, usize)> {
 }
 
 /// Initialise 80×25 text mode and start with a clean screen.
-pub(crate) fn new_text_console(_page_dir_ptr: &mut x86::registers::bits32::paging::PD) {
+pub fn new_text_console(_page_dir_ptr: &mut x86::registers::bits32::paging::PD) {
     // Program 80×25 text mode
     VgaDevice::set_mode(VgaMode::Text80x25);
 


### PR DESCRIPTION
workflow: refactor(x86_q35): remove hidden static_init paths; constru…ct Pc + UARTs directly

chip.rs: add x86_low_level_init() and vga_early_clear(), export Pc only; drop PcComponent.

serial.rs: add unsafe SerialPort::new(base); remove Component + serial_port_component_static!.

lib.rs: re-export Pc, x86_low_level_init, vga_early_clear; keep modules tidy.

board/main.rs: call low-level init, build COM1–COM4, VGA, PIT directly, register deferred calls, create Pc via Pc::new, init paging.

### Pull Request Overview

This pull request refactors how the chip crate is built without the use of `static_init`


### Testing Strategy

This pull request was tested by @domnudragota 


### TODO or Help Wanted

This pull request still needs whole implementation and guidance, this is just a stub


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
