### PR TITLE
add gpio driver

### DIFF
--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -234,7 +234,7 @@ unsafe fn start() -> (
             )
         ),
     )
-    .finalize(components::gpio_component_static!(stm32u545::gpio::Pin));
+    .finalize(components::button_component_static!(stm32u545::gpio::Pin));
     let gpio = GpioComponent::new(
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -236,7 +236,7 @@ unsafe fn start() -> (
     )
     .finalize(components::button_component_static!(stm32u545::gpio::Pin));
 
-    /// Initialization of GPIO ports A,B,C
+    // Initialization of GPIO ports A,B,C
     let gpio = GpioComponent::new(
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -235,6 +235,8 @@ unsafe fn start() -> (
         ),
     )
     .finalize(components::button_component_static!(stm32u545::gpio::Pin));
+
+    /// Initialization of GPIO ports A,B,C
     let gpio = GpioComponent::new(
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,

--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 
+use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
@@ -44,6 +45,7 @@ struct NucleoU545RE {
         kernel::hil::led::LedHigh<'static, stm32u545::gpio::Pin<'static>>,
         1,
     >,
+    gpio: &'static capsules_core::gpio::GPIO<'static, stm32u545::gpio::Pin<'static>>,
     button: &'static capsules_core::button::Button<'static, stm32u545::gpio::Pin<'static>>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
@@ -64,6 +66,7 @@ impl SyscallDriverLookup for NucleoU545RE {
             capsules_core::led::DRIVER_NUM => f(Some(self.led)),
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::gpio::DRIVER_NUM => f(Some(self.gpio)),
             _ => f(None),
         }
     }
@@ -231,7 +234,33 @@ unsafe fn start() -> (
             )
         ),
     )
-    .finalize(components::button_component_static!(stm32u545::gpio::Pin));
+    .finalize(components::gpio_component_static!(stm32u545::gpio::Pin));
+    let gpio = GpioComponent::new(
+        board_kernel,
+        capsules_core::gpio::DRIVER_NUM,
+        components::gpio_component_helper!(
+            stm32u545::gpio::Pin,
+            // Arduino like RX/TX
+            // 0 => static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin03)), //D0
+            // 1 => static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin02)), //D1
+
+            2 => static_init!(stm32u545::gpio::Pin,periphs.gpio_c.pin(PinId::Pin08)),//D2
+            3 => static_init!(stm32u545::gpio::Pin, periphs.gpio_b.pin(PinId::Pin03)), //D3
+            4 => static_init!(stm32u545::gpio::Pin,periphs.gpio_b.pin(PinId::Pin05)), //D4
+            5 => static_init!(stm32u545::gpio::Pin, periphs.gpio_b.pin(PinId::Pin04)), //D5
+            6 => static_init!(stm32u545::gpio::Pin, periphs.gpio_b.pin(PinId::Pin10)), //D6
+            7 => static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin08)), //D7
+            8 => static_init!(stm32u545::gpio::Pin, periphs.gpio_c.pin(PinId::Pin07)), //D8
+            9 => static_init!(stm32u545::gpio::Pin, periphs.gpio_c.pin(PinId::Pin06)), //D9
+            10 =>  static_init!(stm32u545::gpio::Pin, periphs.gpio_c.pin(PinId::Pin09)), //D10
+            11 =>  static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin07)), //D11
+            12 =>  static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin06)), //D12
+            13 =>  static_init!(stm32u545::gpio::Pin, periphs.gpio_a.pin(PinId::Pin05)), //D13
+            14 =>  static_init!(stm32u545::gpio::Pin, periphs.gpio_b.pin(PinId::Pin07)), //D14
+            15 =>  static_init!(stm32u545::gpio::Pin, periphs.gpio_b.pin(PinId::Pin06)), //D15
+        ),
+    )
+    .finalize(components::gpio_component_static!(stm32u545::gpio::Pin));
 
     // Platform and Interrupts
     let platform = static_init!(
@@ -244,6 +273,7 @@ unsafe fn start() -> (
             led,
             button,
             alarm,
+            gpio
         }
     );
 

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -60,6 +60,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         // Power and Wires
         self.rcc.enable_dma1();
         self.rcc.enable_gpioa();
+        self.rcc.enable_gpiob();
         self.rcc.enable_gpioc();
         self.rcc.enable_usart1();
         self.rcc.enable_syscfg();

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -51,7 +51,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
             exti,
             dma1,
             gpio_a: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortA),
-            gpio_b: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortB),
+            gpio_b: gpio::Port::new(gpio::GPIO_B_BASE, exti, gpio::GpioPort::PortB),
             gpio_c: gpio::Port::new(gpio::GPIO_C_BASE, exti, gpio::GpioPort::PortC),
         }
     }

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -33,6 +33,7 @@ pub struct Stm32u5xxDefaultPeripherals<'a> {
     pub exti: &'a exti::Exti<'a>,
     pub dma1: &'a Dma,
     pub gpio_a: gpio::Port<'a>,
+    pub gpio_b: gpio::Port<'a>,
     pub gpio_c: gpio::Port<'a>,
 }
 
@@ -50,6 +51,7 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
             exti,
             dma1,
             gpio_a: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortA),
+            gpio_b: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortB),
             gpio_c: gpio::Port::new(gpio::GPIO_C_BASE, exti, gpio::GpioPort::PortC),
         }
     }

--- a/chips/stm32u5xx/src/gpio.rs
+++ b/chips/stm32u5xx/src/gpio.rs
@@ -351,6 +351,9 @@ register_bitfields![u32,
 pub const GPIO_A_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020000 as *const GpioRegisters) };
 
+pub const GPIO_B_BASE: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new(0x52020400 as *const GpioRegisters) };
+
 pub const GPIO_C_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020800 as *const GpioRegisters) };
 

--- a/chips/stm32u5xx/src/gpio.rs
+++ b/chips/stm32u5xx/src/gpio.rs
@@ -347,13 +347,13 @@ register_bitfields![u32,
         AF15 OFFSET(28) NUMBITS(4) []
     ]
 ];
-
+/// Secure base address for GPIO Port A registers.
 pub const GPIO_A_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020000 as *const GpioRegisters) };
-
+/// Secure base address for GPIO Port B registers.
 pub const GPIO_B_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020400 as *const GpioRegisters) };
-
+/// Secure base address for GPIO Port C registers.
 pub const GPIO_C_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020800 as *const GpioRegisters) };
 

--- a/chips/stm32u5xx/src/gpio.rs
+++ b/chips/stm32u5xx/src/gpio.rs
@@ -347,6 +347,7 @@ register_bitfields![u32,
         AF15 OFFSET(28) NUMBITS(4) []
     ]
 ];
+
 /// Secure base address for GPIO Port A registers.
 pub const GPIO_A_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020000 as *const GpioRegisters) };

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -87,6 +87,10 @@ impl Rcc {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOAEN::SET);
     }
 
+    pub fn enable_gpiob(&self) {
+        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOBEN::SET);
+    }
+
     pub fn enable_gpioc(&self) {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOCEN::SET);
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds GPIO driver initialization for the U545RE-Q and fixes the previous compilation error due to the wrong finalization type inferred. 


### Testing Strategy

This pull request was tested by compiling the Tock OS on the Nucleo STM U545RE-Q


### TODO or Help Wanted

This pull request still needs review


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
