### PR TITLE
chips: stm32u5xx: Implemented SPI Master driver

### DIFF
--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -10,6 +10,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::debug::PanicResources;
 use kernel::deferred_call::DeferredCallClient;
+use kernel::hil::spi::SpiMaster;
 use kernel::platform::chip::Chip;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::utilities::single_thread_value::SingleThreadValue;
@@ -52,6 +53,13 @@ struct NucleoU545RE {
             stm32u545::tim::Tim2<'static>,
         >,
     >,
+    spi: &'static capsules_core::spi_controller::Spi<
+        'static,
+        capsules_core::virtualizers::virtual_spi::VirtualSpiMasterDevice<
+            'static,
+            stm32u545::spi::Spi<'static>,
+        >,
+    >,
 }
 
 impl SyscallDriverLookup for NucleoU545RE {
@@ -64,6 +72,7 @@ impl SyscallDriverLookup for NucleoU545RE {
             capsules_core::led::DRIVER_NUM => f(Some(self.led)),
             capsules_core::button::DRIVER_NUM => f(Some(self.button)),
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules_core::spi_controller::DRIVER_NUM => f(Some(self.spi)),
             _ => f(None),
         }
     }
@@ -118,6 +127,31 @@ unsafe fn set_pin_primary_functions(periphs: &stm32u545::chip::Stm32u5xxDefaultP
     // LED Pin (PA5)
     periphs.gpio_a.pin(PinId::Pin05).make_output();
 
+    // SPI1 Pins
+    // SPI_CLOCK (PB3)
+    // Warning: SCLK used PB3 instead of PA5 because it would conflict with the on-board LED
+    let spi1_sck = periphs.gpio_b.pin(PinId::Pin03);
+    spi1_sck.set_mode(stm32u545::gpio::Mode::AlternateFunction);
+    spi1_sck.set_alternate_function(5);
+    spi1_sck.set_speed_high();
+
+    // SPI_MISO (PA6)
+    let spi1_miso = periphs.gpio_a.pin(PinId::Pin06);
+    spi1_miso.set_mode(stm32u545::gpio::Mode::AlternateFunction);
+    spi1_miso.set_alternate_function(5);
+    spi1_miso.set_speed_high();
+
+    // SPI_MOSI (PA7)
+    let spi1_mosi = periphs.gpio_a.pin(PinId::Pin07);
+    spi1_mosi.set_mode(stm32u545::gpio::Mode::AlternateFunction);
+    spi1_mosi.set_alternate_function(5);
+    spi1_mosi.set_speed_high();
+
+    // SPI1_CS (PC9)
+    let spi1_cs = periphs.gpio_c.pin(PinId::Pin09);
+    spi1_cs.set_mode(stm32u545::gpio::Mode::Output);
+    spi1_cs.set_speed_high();
+
     // Button Pin (PC13) - Hardware is Active High
     let btn = periphs.gpio_c.pin(PinId::Pin13);
     btn.make_input();
@@ -152,10 +186,15 @@ unsafe fn start() -> (
     );
     usart1.register();
 
+    let spi1 = static_init!(
+        stm32u545::spi::Spi<'static>,
+        stm32u545::spi::Spi::new(stm32u545::spi::SPI1_BASE)
+    );
+
     // Load Peripherals Bundle
     let periphs = static_init!(
         stm32u545::chip::Stm32u5xxDefaultPeripherals<'static>,
-        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, exti, dma1)
+        stm32u545::chip::Stm32u5xxDefaultPeripherals::new(usart1, spi1, exti, dma1)
     );
 
     // Initialize wiring (DMA, clocks)
@@ -172,6 +211,9 @@ unsafe fn start() -> (
 
     let uart_mux = components::console::UartMuxComponent::new(periphs.usart1, 115200)
         .finalize(components::uart_mux_component_static!());
+
+    let spi_mux = components::spi::SpiMuxComponent::new(periphs.spi1)
+        .finalize(components::spi_mux_component_static!(stm32u545::spi::Spi));
 
     let alarm_mux = components::alarm::AlarmMuxComponent::new(&periphs.tim2).finalize(
         components::alarm_mux_component_static!(stm32u545::tim::Tim2),
@@ -219,6 +261,24 @@ unsafe fn start() -> (
         kernel::hil::led::LedHigh::new(led_pin)
     ));
 
+    let spi_cs = static_init!(
+        stm32u545::gpio::Pin<'static>,
+        periphs.gpio_c.pin(PinId::Pin09)
+    );
+
+    kernel::hil::gpio::Configure::make_output(spi_cs);
+    kernel::hil::gpio::Output::set(spi_cs);
+
+    let spi_syscalls = components::spi::SpiSyscallComponent::new(
+        board_kernel,
+        spi_mux,
+        spi_cs,
+        capsules_core::spi_controller::DRIVER_NUM,
+    )
+    .finalize(components::spi_syscall_component_static!(
+        stm32u545::spi::Spi<'static>
+    ));
+
     let button = components::button::ButtonComponent::new(
         board_kernel,
         capsules_core::button::DRIVER_NUM,
@@ -244,6 +304,7 @@ unsafe fn start() -> (
             led,
             button,
             alarm,
+            spi: spi_syscalls,
         }
     );
 
@@ -251,6 +312,8 @@ unsafe fn start() -> (
         stm32u545::chip::Stm32u5xx<stm32u545::chip::Stm32u5xxDefaultPeripherals>,
         stm32u545::chip::Stm32u5xx::new(periphs)
     );
+
+    let _ = spi1.init();
 
     // Symbols for linker
     extern "C" {

--- a/chips/stm32u545/src/lib.rs
+++ b/chips/stm32u545/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 
-pub use stm32u5xx::{chip, dma, exti, gpio, rcc, tim, usart};
+pub use stm32u5xx::{chip, dma, exti, gpio, rcc, spi, tim, usart};
 
 use cortexm33::{CortexM33, CortexMVariant};
 

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -10,9 +10,10 @@ use crate::nvic::{
     EXTI13_IRQ, GPDMA1_CH0_IRQ, GPDMA1_CH10_IRQ, GPDMA1_CH11_IRQ, GPDMA1_CH12_IRQ, GPDMA1_CH13_IRQ,
     GPDMA1_CH14_IRQ, GPDMA1_CH15_IRQ, GPDMA1_CH1_IRQ, GPDMA1_CH2_IRQ, GPDMA1_CH3_IRQ,
     GPDMA1_CH4_IRQ, GPDMA1_CH5_IRQ, GPDMA1_CH6_IRQ, GPDMA1_CH7_IRQ, GPDMA1_CH8_IRQ, GPDMA1_CH9_IRQ,
-    TIM2_IRQ, USART1_IRQ,
+    SPI1_IRQ, TIM2_IRQ, USART1_IRQ,
 };
 use crate::rcc;
+use crate::spi;
 use crate::tim;
 use crate::usart;
 
@@ -30,9 +31,11 @@ pub struct Stm32u5xxDefaultPeripherals<'a> {
     pub rcc: rcc::Rcc,
     pub tim2: tim::Tim2<'a>,
     pub usart1: &'a usart::Usart<'a>,
+    pub spi1: &'a spi::Spi<'a>,
     pub exti: &'a exti::Exti<'a>,
     pub dma1: &'a Dma,
     pub gpio_a: gpio::Port<'a>,
+    pub gpio_b: gpio::Port<'a>,
     pub gpio_c: gpio::Port<'a>,
 }
 
@@ -42,14 +45,21 @@ fn enable_tim2_clock() {
 }
 
 impl<'a> Stm32u5xxDefaultPeripherals<'a> {
-    pub fn new(usart1: &'a usart::Usart<'a>, exti: &'a exti::Exti<'a>, dma1: &'a Dma) -> Self {
+    pub fn new(
+        usart1: &'a usart::Usart<'a>,
+        spi1: &'a spi::Spi<'a>,
+        exti: &'a exti::Exti<'a>,
+        dma1: &'a Dma,
+    ) -> Self {
         Self {
             rcc: rcc::Rcc::new(rcc::RCC_BASE),
             tim2: tim::Tim2::new(tim::TIM2_BASE, enable_tim2_clock),
             usart1,
+            spi1,
             exti,
             dma1,
             gpio_a: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortA),
+            gpio_b: gpio::Port::new(gpio::GPIO_B_BASE, exti, gpio::GpioPort::PortB),
             gpio_c: gpio::Port::new(gpio::GPIO_C_BASE, exti, gpio::GpioPort::PortC),
         }
     }
@@ -58,8 +68,10 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
         // Power and Wires
         self.rcc.enable_dma1();
         self.rcc.enable_gpioa();
+        self.rcc.enable_gpiob();
         self.rcc.enable_gpioc();
         self.rcc.enable_usart1();
+        self.rcc.enable_spi1();
         self.rcc.enable_syscfg();
         self.rcc.set_usart1_source_pclk();
         // Link DMA to USART1
@@ -68,6 +80,14 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
 
         if let (Some(tx), Some(rx)) = (usart1_channel_tx, usart1_channel_rx) {
             usart::Usart::set_dma(self.usart1, self.dma1, tx, rx);
+        }
+
+        // Link DMA to SPI1
+        let spi1_channel_tx = self.dma1.request_channel();
+        let spi1_channel_rx = self.dma1.request_channel();
+
+        if let (Some(tx), Some(rx)) = (spi1_channel_tx, spi1_channel_rx) {
+            spi::Spi::set_dma(self.spi1, self.dma1, tx, rx);
         }
     }
 }
@@ -83,6 +103,11 @@ impl InterruptService for Stm32u5xxDefaultPeripherals<'_> {
             USART1_IRQ => {
                 // USART1
                 self.usart1.handle_interrupt();
+                true
+            }
+            SPI1_IRQ => {
+                // SPI1
+                self.spi1.handle_interrupt();
                 true
             }
             EXTI13_IRQ => {

--- a/chips/stm32u5xx/src/dma.rs
+++ b/chips/stm32u5xx/src/dma.rs
@@ -11,16 +11,23 @@ use kernel::utilities::registers::{
 use kernel::utilities::StaticRef;
 
 /// Base address for USART1 in Secure Alias mode.
-const USART1_BASE_ADDR: u32 = 0x50013800;
+const USART1_BASE_ADDR: u32 = 0x5001_3800;
 /// USART1 Receive Data Register (RDR) address.
 const USART1_RDR: u32 = USART1_BASE_ADDR + 0x24;
 /// USART1 Transmit Data Register (TDR) address.
 const USART1_TDR: u32 = USART1_BASE_ADDR + 0x28;
 
+/// Base address for SPI1 in Secure Alias mode.
+const SPI1_BASE_ADDR: u32 = 0x5001_3000;
+const SPI1_RXDR: u32 = SPI1_BASE_ADDR + 0x030;
+const SPI1_TXDR: u32 = SPI1_BASE_ADDR + 0x020;
+
 /// GPDMA Request Selection IDs (REQSEL)
 /// Found in the GPDMA request multiplexer table of the STM32U5 reference manual.
 const GPDMA_REQ_USART1_RX: u32 = 24;
 const GPDMA_REQ_USART1_TX: u32 = 25;
+const GPDMA_REQ_SPI1_RX: u32 = 6;
+const GPDMA_REQ_SPI1_TX: u32 = 7;
 
 register_bitfields! [
     u32,
@@ -205,6 +212,8 @@ pub enum DmaDirection {
 pub enum DmaPeripheral {
     Usart1Tx,
     Usart1Rx,
+    Spi1Tx,
+    Spi1Rx,
 }
 
 impl DmaPeripheral {
@@ -218,6 +227,16 @@ impl DmaPeripheral {
             DmaPeripheral::Usart1Rx => (
                 USART1_RDR,
                 GPDMA_REQ_USART1_RX,
+                DmaDirection::PeripheralToMemory,
+            ),
+            DmaPeripheral::Spi1Tx => (
+                SPI1_TXDR,
+                GPDMA_REQ_SPI1_TX,
+                DmaDirection::MemoryToPeripheral,
+            ),
+            DmaPeripheral::Spi1Rx => (
+                SPI1_RXDR,
+                GPDMA_REQ_SPI1_RX,
                 DmaDirection::PeripheralToMemory,
             ),
         }

--- a/chips/stm32u5xx/src/gpio.rs
+++ b/chips/stm32u5xx/src/gpio.rs
@@ -351,6 +351,9 @@ register_bitfields![u32,
 pub const GPIO_A_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020000 as *const GpioRegisters) };
 
+pub const GPIO_B_BASE: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new(0x52020400 as *const GpioRegisters) };
+
 pub const GPIO_C_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x52020800 as *const GpioRegisters) };
 

--- a/chips/stm32u5xx/src/lib.rs
+++ b/chips/stm32u5xx/src/lib.rs
@@ -10,6 +10,7 @@ pub mod exti;
 pub mod gpio;
 pub mod nvic;
 pub mod rcc;
+pub mod spi;
 pub mod tim;
 pub mod usart;
 

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -51,7 +51,8 @@ register_bitfields![u32,
         TIM2EN OFFSET(0) NUMBITS(1) []
     ],
     pub APB2ENR [
-        USART1EN OFFSET(14) NUMBITS(1) []
+        USART1EN OFFSET(14) NUMBITS(1) [],
+        SPI1EN OFFSET(12) NUMBITS(1) []
     ],
     pub APB3ENR [
         SYSCFGEN OFFSET(1) NUMBITS(1) []
@@ -89,6 +90,10 @@ impl Rcc {
 
     pub fn enable_gpioc(&self) {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOCEN::SET);
+    }
+
+    pub fn enable_spi1(&self) {
+        self.registers.apb2enr.modify(APB2ENR::SPI1EN::SET);
     }
 
     pub fn enable_usart1(&self) {

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -88,6 +88,10 @@ impl Rcc {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOAEN::SET);
     }
 
+    pub fn enable_gpiob(&self) {
+        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOBEN::SET);
+    }
+
     pub fn enable_gpioc(&self) {
         self.registers.ahb2enr1.modify(AHB2ENR1::GPIOCEN::SET);
     }

--- a/chips/stm32u5xx/src/spi.rs
+++ b/chips/stm32u5xx/src/spi.rs
@@ -2,6 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2026.
 
+use crate::dma::{ChannelId, Dma};
+use core::cell::Cell;
+use core::cmp;
+use cortexm33::dma_fence::CortexMDmaFence;
+use kernel::hil::gpio::Output;
+use kernel::hil::spi::{self, ClockPhase, ClockPolarity};
+use kernel::utilities::cells::{MapCell, OptionalCell};
+use kernel::utilities::dma_slice::DmaSubSliceMut;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
 };
@@ -9,50 +18,46 @@ use kernel::utilities::StaticRef;
 
 register_structs! {
     pub SpiRegisters {
-        //Control register 1
+        /// Control register 1
         (0x000 => cr1: ReadWrite<u32, CR1::Register>),
-        //Control register 2
+        /// Control register 2
         (0x004 => cr2: ReadWrite<u32, CR2::Register>),
-        //Configuration register 1
+        /// Configuration register 1
         (0x008 => cfg1: ReadWrite<u32, CFG1::Register>),
-        //Configuration register 2
+        /// Configuration register 2
         (0x00C => cfg2: ReadWrite<u32, CFG2::Register>),
-        //Interrupt enable register
+        /// Interrupt enable register
         (0x010 => ier: ReadWrite<u32, IER::Register>),
-        //Status register
+        /// Status register
         (0x014 => sr: ReadOnly<u32, SR::Register>),
-        //Interrupt/status flags clear register
+        /// Interrupt/status flags clear register
         (0x018 => ifcr: WriteOnly<u32, IFCR::Register>),
-        //Autonomous mode control register
+        /// Autonomous mode control register
         (0x01C => autocr: ReadWrite<u32, AUTOCR::Register>),
-        //Transmit data register
+        /// Transmit data register
         (0x020 => txdr: WriteOnly<u32, TXDR::Register>),
         (0x024 => _reserved0),
-        //Receive data register
+        /// Receive data register
         (0x030 => rxdr: ReadOnly<u32, RXDR::Register>),
         (0x034 => _reserved1),
-        //Polynomial register
+        /// Polynomial register
         (0x040 => crcpoly: ReadWrite<u32, CRCPOLY::Register>),
-        //Transmitter CRC register
+        /// Transmitter CRC register
         (0x044 => txcrc: ReadOnly<u32, TXCRC::Register>),
-        //Receiver CRC register
+        /// Receiver CRC register
         (0x048 => rxcrc: ReadOnly<u32, RXCRC::Register>),
-        //Underrun data register
+        /// Underrun data register
         (0x04C => udrdr: ReadWrite<u32, UDRDR::Register>),
         (0x050 => @END),
     }
 }
 
-// Base addresses for SPI1, 2 and 3 in Secure Alias mode
+// Base addresses for SPI1 in Secure Alias mode
 pub const SPI1_BASE: StaticRef<SpiRegisters> =
     unsafe { StaticRef::new(0x5001_3000 as *const SpiRegisters) };
-// pub const SPI2_BASE: StaticRef<SpiRegisters> =
-//     unsafe { StaticRef::new(0x5000_3800 as *const SpiRegisters) }; //not used
-// pub const SPI3_BASE: StaticRef<SpiRegisters> =
-//     unsafe { StaticRef::new(0x5600_2000 as *const SpiRegisters) }; //not used
 
 register_bitfields![u32,
-    // Control Register 1
+    /// Control Register 1
     pub CR1 [
         /// Locking the AF configuration of associated I/Os
         /// 0: AF configuration is not locked
@@ -105,13 +110,13 @@ register_bitfields![u32,
         SPE OFFSET(0) NUMBITS(1) []
     ],
 
-    // Control Register 2
+    /// Control Register 2
     pub CR2 [
-        ///Number of data at current transfer
+        /// Number of data at current transfer
         TSIZE OFFSET(0)  NUMBITS(16) []
     ],
 
-    // SPI configuration register 1
+    /// SPI configuration register 1
     pub CFG1 [
         /// Bypass of the prescaler at master baud rate clock generator
         /// 0: bypass is disabled
@@ -165,7 +170,7 @@ register_bitfields![u32,
         DSIZE OFFSET(0) NUMBITS(5) []
     ],
 
-    // SPI configuration register 2
+    /// SPI configuration register 2
     pub CFG2 [
         /// Alternate function GPIOs control
         /// This bit is taken into account when SPE = 0 only.
@@ -199,34 +204,34 @@ register_bitfields![u32,
         // 1: SCK signal is at 1 when idle
         CPOL OFFSET(25) NUMBITS(1) [],
 
-        // clock phase
-        // 0: the first clock transition is the first data capture edge
-        // 1: the second clock transition is the first data capture edge
+        /// Clock Phase
+        /// 0: the first clock transition is the first data capture edge
+        /// 1: the second clock transition is the first data capture edge
         CPHA OFFSET(24) NUMBITS(1) [],
 
-        // data frame format
-        // 0: MSB transmitted first
-        // 1: LSB transmitted first
+        /// data frame format
+        /// 0: MSB transmitted first
+        /// 1: LSB transmitted first
         LSBFRST OFFSET(23) NUMBITS(1) [],
 
-        // SPI master
-        // 0: SPI slave
-        // 1: SPI master
+        /// SPI master
+        /// 0: SPI slave
+        /// 1: SPI master
         MASTER OFFSET(22) NUMBITS(1) [],
 
-        // Serial protocol
-        // 000: SPI Motorola
-        // 001: SPI TI
+        /// Serial protocol
+        /// 000: SPI Motorola
+        /// 001: SPI TI
         SP OFFSET(19) NUMBITS(3) [
             Motorola = 0b000,
             Ti = 0b001
         ],
 
-        // SPI Communication Mode
-        // 00: full-duplex
-        // 01: simplex transmitter
-        // 10: simplex receiver
-        // 11: half-duplex
+        /// SPI Communication Mode
+        /// 00: full-duplex
+        /// 01: simplex transmitter
+        /// 10: simplex receiver
+        /// 11: half-duplex
         COMM OFFSET(17) NUMBITS(2) [
             FullDuplex = 0b00,
             SimplexTx = 0b01,
@@ -234,177 +239,617 @@ register_bitfields![u32,
             HalfDuplex = 0b11
         ],
 
-        // Swap functionality of MISO and MOSI pins
-        // 0: no swap
-        // 1: MOSI and MISO are swapped
+        /// Swap functionality of MISO and MOSI pins
+        /// 0: no swap
+        /// 1: MOSI and MISO are swapped
         IOSWP OFFSET(15) NUMBITS(1) [],
 
-        // RDY signal input/output polarity
-        // 0: high level of the signal means the slave is ready for communication
-        // 1: low level of the signal means the slave is ready for communication
+        /// RDY signal input/output polarity
+        /// 0: high level of the signal means the slave is ready for communication
+        /// 1: low level of the signal means the slave is ready for communication
         RDIOP OFFSET(14) NUMBITS(1) [],
 
-        // RDY signal input/output management
-        // 0: RDY signal is defined internally fixed as permanently active (RDIOP setting has no effect)
-        // 1: RDY signal is overtaken from alternate function input (at master case) or output (at slave case)
+        /// RDY signal input/output management
+        /// 0: RDY signal is defined internally fixed as permanently active (RDIOP setting has no effect)
+        /// 1: RDY signal is overtaken from alternate function input (at master case) or output (at slave case)
         RDIOM OFFSET(13) NUMBITS(1) [],
 
-        // Master Inter-Data Idleness
-        // Specifies minimum time delay (expressed in SPI clock cycles periods) inserted between two
-        // consecutive data frames in master mode.
+        /// Master Inter-Data Idleness
+        /// Specifies minimum time delay (expressed in SPI clock cycles periods) inserted between two
+        /// consecutive data frames in master mode.
         MIDI OFFSET(4) NUMBITS(4) [],
 
-        // Master NSS Idleness
-        // Specifies an extra delay, expressed in number of SPI clock cycle periods, inserted
-        // additionally between active edge of NSS opening a session and the beginning of the first
-        // data frame of the session in master mode when SSOE is enabled.
+        /// Master NSS Idleness
+        /// Specifies an extra delay, expressed in number of SPI clock cycle periods, inserted
+        /// additionally between active edge of NSS opening a session and the beginning of the first
+        /// data frame of the session in master mode when SSOE is enabled.
         MSSI OFFSET(0) NUMBITS(4) []
     ],
 
-    // SPI interrupt enable register
+    /// SPI interrupt enable register
     pub IER [
-        // Mode Fault interrupt enable
+        /// Mode Fault interrupt enable
         MODFIE OFFSET(9) NUMBITS(1) [],
 
-        // TIFRE interrupt enable
+        /// TIFRE interrupt enable
         TIFREIE OFFSET(8) NUMBITS(1) [],
 
-        // CRC error interrupt enable
+        /// CRC error interrupt enable
         CRCEIE OFFSET(7) NUMBITS(1) [],
 
-        // OVR interrupt enable
+        /// OVR interrupt enable
         OVRIE OFFSET(6) NUMBITS(1) [],
 
-        // UDR interrupt enable
+        /// UDR interrupt enable
         UDRIE OFFSET(5) NUMBITS(1) [],
 
-        // TXTF interrupt enable
+        /// TXTF interrupt enable
         TXTFIE OFFSET(4) NUMBITS(1) [],
 
-        // EOT, SUSP and TXC interrupt enable
+        /// EOT, SUSP and TXC interrupt enable
         EOTIE OFFSET(3) NUMBITS(1) [],
 
-        // DXP interrupt enabled
+        /// DXP interrupt enabled
         DXPIE OFFSET(2) NUMBITS(1) [],
 
-        // TXP interrupt enabled
+        /// TXP interrupt enabled
         TXPIE OFFSET(1) NUMBITS(1) [],
 
-        // RXP interrupt enabled
+        /// RXP interrupt enabled
         RXPIE OFFSET(0) NUMBITS(1) []
     ],
 
-    // SPI status register
+    /// SPI status register
     pub SR [
-        // number of data frames remaining in current TSIZE session
+        /// number of data frames remaining in current TSIZE session
         CTSIZE OFFSET(16) NUMBITS(16) [],
 
-        // RxFIFO word not empty
+        /// RxFIFO word not empty
         RXWNE OFFSET(15) NUMBITS(1) [],
 
-        // RxFIFO packing level
+        /// RxFIFO packing level
         RXPLVL OFFSET(13) NUMBITS(2) [],
 
-        // TxFIFO transmission complete
+        /// TxFIFO transmission complete
         TXC OFFSET(12) NUMBITS(1) [],
 
-        // Suspension status
+        /// Suspension status
         SUSP OFFSET(11) NUMBITS(1) [],
 
-        // Mode fault
+        /// Mode fault
         MODF OFFSET(9) NUMBITS(1) [],
 
-        // TI frame format error
+        /// TI frame format error
         TIFRE OFFSET(8) NUMBITS(1) [],
 
-        // CRC error
+        /// CRC error
         CRCE OFFSET(7) NUMBITS(1) [],
 
-        // Overrun
+        /// Overrun
         OVR OFFSET(6) NUMBITS(1) [],
 
-        // Underrun
+        /// Underrun
         UDR OFFSET(5) NUMBITS(1) [],
 
-        // Transmission transfer filled
+        /// Transmission transfer filled
         TXTF OFFSET(4) NUMBITS(1) [],
 
-        // End of transfer
+        /// End of transfer
         EOT OFFSET(3) NUMBITS(1) [],
 
-        // Duplex packet
+        /// Duplex packet
         DXP OFFSET(2) NUMBITS(1) [],
 
-        // Tx-packet space available
+        /// Tx-packet space available
         TXP OFFSET(1) NUMBITS(1) [],
 
-        // RXP: Rx-packet available
+        /// RXP: Rx-packet available
         RXP OFFSET(0) NUMBITS(1) []
     ],
 
     /// SPI interrupt/status flags clear register
     pub IFCR [
-        // Suspend flag clear
+        /// Suspend flag clear
         SUSPC OFFSET(11) NUMBITS(1) [],
-        // Mode fault flag clear
+        /// Mode fault flag clear
         MODFC OFFSET(9) NUMBITS(1) [],
-        // TI frame format error flag clear
+        /// TI frame format error flag clear
         TIFREC OFFSET(8) NUMBITS(1) [],
-        // CRC error flag clear
+        /// CRC error flag clear
         CRCEC OFFSET(7) NUMBITS(1) [],
-        // Overrun flag clear
+        /// Overrun flag clear
         OVRC OFFSET(6) NUMBITS(1) [],
-        // Underrun flag clear
+        /// Underrun flag clear
         UDRC OFFSET(5) NUMBITS(1) [],
-        // Transmission transfer filled flag clear
+        /// Transmission transfer filled flag clear
         TXTFC OFFSET(4) NUMBITS(1) [],
-        // End of transfer flag clear
+        /// End of transfer flag clear
         EOTC OFFSET(3) NUMBITS(1) []
     ],
 
     /// SPI autonomous mode control register
     pub AUTOCR [
-        // Hardware control of CSTART triggering enable
+        /// Hardware control of CSTART triggering enable
         TRIGEN OFFSET(21) NUMBITS(1) [],
-        // Trigger polarity
+        /// Trigger polarity
         TRIGPOL OFFSET(20) NUMBITS(1) [],
-        // Trigger selection
+        /// Trigger selection
         TRIGSEL OFFSET(16) NUMBITS(4) []
     ],
 
     /// SPI transmit data register
     pub TXDR[
-        // Transmit data register
+        /// Transmit data register
         TXDR OFFSET(0) NUMBITS(32) []
     ],
 
     /// SPI receive data register
     pub RXDR [
-        // Receive data register
+        /// Receive data register
         RXDR OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI polynomial register
+    /// SPI polynomial register
     pub CRCPOLY [
-        // CRC polynomial register
+        /// CRC polynomial register
         CRCPOLY OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI transmitter CRC register
+    /// SPI transmitter CRC register
     pub TXCRC [
-        // CRC register for transmitter
+        /// CRC register for transmitter
         TXCRC OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI receiver CRC register
+    /// SPI receiver CRC register
     pub RXCRC [
-        // CRC register for receiver
+        /// CRC register for receiver
         RXCRC OFFSET(0) NUMBITS(32) []
     ],
 
-    // SPI underrun data register
+    /// SPI underrun data register
     pub UDRDR [
-        // Data at slave underrun condition
+        /// Data at slave underrun condition
         UDRDR OFFSET(0) NUMBITS(32) []
     ]
 ];
+
+pub struct Spi<'a> {
+    pub registers: StaticRef<SpiRegisters>,
+    client: OptionalCell<&'a dyn spi::SpiMasterClient>,
+    dma: OptionalCell<&'a Dma>,
+    dma_channel_tx: Cell<Option<ChannelId>>,
+    dma_channel_rx: Cell<Option<ChannelId>>,
+    tx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+    rx_dma_buf: MapCell<DmaSubSliceMut<'static, u8>>,
+    dma_len: Cell<usize>,
+    transfers_in_progress: Cell<u8>,
+    active_slave: OptionalCell<&'a crate::gpio::Pin<'a>>,
+    active_after: Cell<bool>,
+}
+
+impl<'a> Spi<'a> {
+    pub fn new(base: StaticRef<SpiRegisters>) -> Self {
+        Self {
+            registers: base,
+            client: OptionalCell::empty(),
+            dma: OptionalCell::empty(),
+            dma_channel_tx: Cell::new(None),
+            dma_channel_rx: Cell::new(None),
+            tx_dma_buf: MapCell::empty(),
+            rx_dma_buf: MapCell::empty(),
+            dma_len: Cell::new(0),
+            transfers_in_progress: Cell::new(0),
+            active_slave: OptionalCell::empty(),
+            active_after: Cell::new(false),
+        }
+    }
+
+    /// Associates a DMA controller and channels with the SPI driver
+    pub fn set_dma(spi: &'static Self, dma: &'a Dma, tx_channel: ChannelId, rx_channel: ChannelId) {
+        spi.dma.set(dma);
+        spi.dma_channel_tx.set(Some(tx_channel));
+        spi.dma_channel_rx.set(Some(rx_channel));
+    }
+
+    pub fn handle_interrupt(&self) {
+        // Used only during debugging. Since we use DMA, we do not enable SPI
+        // interrupts during normal operations
+    }
+
+    fn enable_tx(&self) {
+        self.registers.cfg1.modify(CFG1::TXDMAEN::SET);
+    }
+
+    fn enable_rx(&self) {
+        self.registers.cfg1.modify(CFG1::RXDMAEN::SET);
+    }
+}
+
+impl<'a> spi::SpiMaster<'a> for Spi<'a> {
+    type ChipSelect = &'a crate::gpio::Pin<'a>;
+
+    fn set_phase(&self, phase: ClockPhase) -> Result<(), kernel::ErrorCode> {
+        match phase {
+            ClockPhase::SampleLeading => {
+                self.registers.cfg2.modify(CFG2::CPHA::CLEAR);
+            }
+            ClockPhase::SampleTrailing => {
+                self.registers.cfg2.modify(CFG2::CPHA::SET);
+            }
+        }
+        Ok(())
+    }
+
+    fn set_polarity(&self, polarity: ClockPolarity) -> Result<(), kernel::ErrorCode> {
+        match polarity {
+            ClockPolarity::IdleLow => {
+                self.registers.cfg2.modify(CFG2::CPOL::CLEAR);
+            }
+            ClockPolarity::IdleHigh => {
+                self.registers.cfg2.modify(CFG2::CPOL::SET);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_phase(&self) -> ClockPhase {
+        if !self.registers.cfg2.is_set(CFG2::CPHA) {
+            ClockPhase::SampleLeading
+        } else {
+            ClockPhase::SampleTrailing
+        }
+    }
+
+    fn get_polarity(&self) -> ClockPolarity {
+        if !self.registers.cfg2.is_set(CFG2::CPOL) {
+            ClockPolarity::IdleLow
+        } else {
+            ClockPolarity::IdleHigh
+        }
+    }
+
+    fn set_rate(&self, rate: u32) -> Result<u32, kernel::ErrorCode> {
+        // According to the datasheet we cannot set a specific baudrate, we can
+        // only prescale the clock entering SPI. By default SPI uses PCLK2. This
+        // function tries to find a divider value that gets us as close as
+        // possible to the desired rate
+
+        // SPI1 uses PCLK2 as per the clock tree in the documentation. Using a logic
+        // analyzer I determined the PCLK2 freq to be 4MHz
+        let spi_clock_freq: u32 = 4_000_000;
+
+        let divider = spi_clock_freq / rate;
+
+        let (mbr_val, actual_rate) = if divider <= 2 {
+            (CFG1::MBR::Div2, spi_clock_freq / 2)
+        } else if divider <= 4 {
+            (CFG1::MBR::Div4, spi_clock_freq / 4)
+        } else if divider <= 8 {
+            (CFG1::MBR::Div8, spi_clock_freq / 8)
+        } else if divider <= 16 {
+            (CFG1::MBR::Div16, spi_clock_freq / 16)
+        } else if divider <= 32 {
+            (CFG1::MBR::Div32, spi_clock_freq / 32)
+        } else if divider <= 64 {
+            (CFG1::MBR::Div64, spi_clock_freq / 64)
+        } else if divider <= 128 {
+            (CFG1::MBR::Div128, spi_clock_freq / 128)
+        } else {
+            (CFG1::MBR::Div256, spi_clock_freq / 256)
+        };
+
+        // Before we can set the rate we need to disable the SPI
+        if self.registers.cr1.is_set(CR1::SPE) {
+            self.registers.cr1.modify(CR1::SPE::CLEAR);
+        }
+
+        self.registers.cfg1.modify(mbr_val);
+
+        if self.registers.cr1.is_set(CR1::SPE) {
+            self.registers.cr1.modify(CR1::SPE::SET);
+        }
+
+        Ok(actual_rate)
+    }
+
+    fn get_rate(&self) -> u32 {
+        // SPI1 uses PCLK2 as per the clock tree in the documentation. Using a logic
+        // analyzer I determined the PCLK2 freq to be 4MHz
+        let spi_clock_freq: u32 = 4_000_000;
+
+        match self.registers.cfg1.read(CFG1::MBR) {
+            0b000 => spi_clock_freq / 2,
+            0b001 => spi_clock_freq / 4,
+            0b010 => spi_clock_freq / 8,
+            0b011 => spi_clock_freq / 16,
+            0b100 => spi_clock_freq / 32,
+            0b101 => spi_clock_freq / 64,
+            0b110 => spi_clock_freq / 128,
+            _ => spi_clock_freq / 256,
+        }
+    }
+
+    fn is_busy(&self) -> bool {
+        // To check for busy status we look at CSTART(master transfer start) and
+        // TXC(TxFifo Transmission Complete) bits
+        self.registers.cr1.is_set(CR1::CSTART) || !self.registers.sr.is_set(SR::TXC)
+    }
+
+    fn hold_low(&self) {
+        // Holds the CS line low after a transfer completes
+        self.active_after.set(true);
+    }
+
+    fn release_low(&self) {
+        // Releases the CS line after a transfer completes
+        self.active_after.set(false);
+    }
+
+    fn init(&self) -> Result<(), kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        // Disable SPI in order to change config bits
+        regs.cr1.modify(CR1::SPE::CLEAR);
+
+        // Set baudrate prescaler to divide the PCLK2(4MHz) by two -> 2MHz
+        // Errata 2.18.1 Workaround: Explicitly force CRCSIZE to 0b00111 (8-bit) to prevent
+        // RxFIFO data corruption when TSIZE > 0 and CRC is disabled
+        regs.cfg1
+            .modify(CFG1::MBR::Div2 + CFG1::CRCSIZE.val(0b00111));
+
+        // Sets SPI to run as Master, in Full-Duplex mode, with Slave-Select managed by software
+        regs.cfg2
+            .modify(CFG2::MASTER::SET + CFG2::SSM::SET + CFG2::COMM::FullDuplex);
+
+        // Forces internal chip select high (inactive) to prevent multi-master collisons (MODFault)
+        regs.cr1.modify(CR1::SSI::SET);
+
+        // Clear any pending mode faults
+        regs.ifcr.write(IFCR::MODFC::SET);
+
+        // Enable SPI
+        regs.cr1.modify(CR1::SPE::SET);
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn spi::SpiMasterClient) {
+        self.client.set(client);
+    }
+
+    fn read_byte(&self) -> Result<u8, kernel::ErrorCode> {
+        self.read_write_byte(0)
+    }
+
+    fn write_byte(&self, val: u8) -> Result<(), kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        // Wait until the FIFO has space
+        while !regs.sr.is_set(SR::TXP) {}
+
+        // Write byte into TXDR (Transmit data register)
+        regs.txdr.write(TXDR::TXDR.val(val as u32));
+
+        // Start transfer
+        regs.cr1.modify(CR1::CSTART::SET);
+
+        // Wait for transfer to finish
+        while !regs.sr.is_set(SR::TXC) {}
+
+        Ok(())
+    }
+
+    fn specify_chip_select(&self, cs: Self::ChipSelect) -> Result<(), kernel::ErrorCode> {
+        self.active_slave.set(cs);
+        Ok(())
+    }
+
+    fn read_write_byte(&self, val: u8) -> Result<u8, kernel::ErrorCode> {
+        let regs = &*self.registers;
+
+        // Disable SPI to modify TSIZE
+        regs.cr1.modify(CR1::SPE::CLEAR);
+
+        // Set the transfer size
+        regs.cr2.modify(CR2::TSIZE.val(1));
+
+        // Enable SPI back on
+        regs.cr1.modify(CR1::SPE::CLEAR);
+
+        // Wait until the TX FIFO actually has space then write the byte
+        while !regs.sr.is_set(SR::TXP) {}
+        regs.txdr.write(TXDR::TXDR.val(val as u32));
+
+        // Start the transfer
+        regs.cr1.modify(CR1::CSTART::SET);
+
+        // Wait for the incoming byte to arrive in the RX FIFO
+        while !regs.sr.is_set(SR::RXP) {}
+
+        // Retrieve the byte
+        let byte = regs.rxdr.get() as u8;
+
+        // Wait for the transfer to finish
+        while !regs.sr.is_set(SR::EOT) {}
+
+        // Clear the completion flags
+        regs.ifcr.write(IFCR::EOTC::SET + IFCR::TXTFC::SET);
+
+        Ok(byte)
+    }
+
+    fn read_write_bytes(
+        &self,
+        mut write_buffer: kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>,
+        read_buffer: Option<kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>>,
+    ) -> Result<
+        (),
+        (
+            kernel::ErrorCode,
+            kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>,
+            Option<kernel::utilities::leasable_buffer::SubSliceMut<'static, u8>>,
+        ),
+    > {
+        let regs = &*self.registers;
+
+        // Check if there is another transaction pending
+        if self.is_busy() {
+            return Err((kernel::ErrorCode::BUSY, write_buffer, read_buffer));
+        }
+
+        // Verify if the DMA is associated with this SPI instance
+        if self.dma.is_none() {
+            return Err((kernel::ErrorCode::OFF, write_buffer, read_buffer));
+        }
+
+        // Pulls CS down to enable the slave
+        self.active_slave.map(|p| {
+            p.clear();
+        });
+
+        // Determine transfer length based on provided buffers
+        let mut count: usize = write_buffer.len();
+        read_buffer
+            .as_ref()
+            .map(|buf| count = cmp::min(count, buf.len()));
+
+        self.dma_len.set(count);
+        // Disable SPI before modifying TSIZE
+        regs.cr1.modify(CR1::SPE::CLEAR);
+
+        // Prevent RX FIFO Overrun by dynamically changing the communication mode.
+        // If we are reading, FullDuplex. If writing only, SimplexTx.
+        if read_buffer.is_some() {
+            regs.cfg2.modify(CFG2::COMM::FullDuplex);
+        } else {
+            regs.cfg2.modify(CFG2::COMM::SimplexTx);
+        }
+
+        // Send the transfer size to hardware
+        regs.cr2.modify(CR2::TSIZE.val(count as u32));
+        self.transfers_in_progress.set(0);
+
+        // Setup RX DMA
+        read_buffer.map(|mut rx_buffer| {
+            self.transfers_in_progress
+                .set(self.transfers_in_progress.get() + 1);
+
+            rx_buffer.slice(0..count);
+            let fence = unsafe { CortexMDmaFence::new() };
+            let dma_slice = DmaSubSliceMut::new_static(rx_buffer, fence);
+
+            let ptr = dma_slice.as_mut_ptr() as u32;
+            let len = dma_slice.len() as u32;
+
+            self.rx_dma_buf.replace(dma_slice);
+
+            self.dma.map(move |dma| {
+                if let Some(ch) = self.dma_channel_rx.get() {
+                    dma.setup(ch, crate::dma::DmaPeripheral::Spi1Rx, ptr, len);
+                    self.enable_rx();
+                }
+            });
+        });
+
+        // Setup TX DMA
+        self.transfers_in_progress
+            .set(self.transfers_in_progress.get() + 1);
+
+        write_buffer.slice(0..count);
+        let fence = unsafe { CortexMDmaFence::new() };
+        let dma_slice = DmaSubSliceMut::new_static(write_buffer, fence);
+
+        let ptr = dma_slice.as_mut_ptr() as u32;
+        let len = dma_slice.len() as u32;
+
+        self.tx_dma_buf.replace(dma_slice);
+
+        self.dma.map(move |dma| {
+            if let Some(ch) = self.dma_channel_tx.get() {
+                dma.setup(ch, crate::dma::DmaPeripheral::Spi1Tx, ptr, len);
+                self.enable_tx();
+            }
+        });
+
+        // Re-enable SPI and clear flags before starting
+        regs.cr1.modify(CR1::SPE::SET);
+        regs.ifcr
+            .write(IFCR::EOTC::SET + IFCR::TXTFC::SET + IFCR::SUSPC::SET);
+
+        // Start the transfer
+        regs.cr1.modify(CR1::CSTART::SET);
+
+        Ok(())
+    }
+}
+
+impl crate::dma::DmaClient for Spi<'_> {
+    /// Callback triggered by the DMA controller hardware interrupt when a
+    /// DMA channel finishes moving its assigned number of bytes.
+    fn transfer_done(&self, channel: ChannelId) {
+        let regs = &*self.registers;
+
+        // Handle TX DMA Channel Completion
+        if let Some(tx_ch) = self.dma_channel_tx.get() {
+            if channel == tx_ch {
+                regs.cfg1.modify(CFG1::TXDMAEN::CLEAR);
+                self.dma.map(|dma| dma.clear_interrupt(tx_ch));
+                self.transfers_in_progress
+                    .set(self.transfers_in_progress.get() - 1);
+            }
+        }
+
+        // Handle RX DMA Channel Completion
+        if let Some(rx_ch) = self.dma_channel_rx.get() {
+            if channel == rx_ch {
+                regs.cfg1.modify(CFG1::RXDMAEN::CLEAR);
+                self.dma.map(|dma| dma.clear_interrupt(rx_ch));
+                self.transfers_in_progress
+                    .set(self.transfers_in_progress.get() - 1);
+            }
+        }
+
+        if self.transfers_in_progress.get() == 0 {
+            // Wait for the transfer to finish so that we don't cutoff
+            // the last byte
+            while !regs.sr.is_set(SR::EOT) {}
+
+            // Clear completion flags
+            regs.ifcr
+                .write(IFCR::EOTC::SET + IFCR::TXTFC::SET + IFCR::OVRC::SET);
+
+            // Pull the CS back up after end of transfer
+            if !self.active_after.get() {
+                self.active_slave.map(|p| {
+                    p.set();
+                });
+            }
+
+            let tx_buffer = self.tx_dma_buf.take().map(|dma_slice| {
+                let fence = unsafe { CortexMDmaFence::new() };
+                let mut subslice = unsafe { dma_slice.take(fence) };
+                subslice.reset();
+                subslice
+            });
+
+            let rx_buffer = self.rx_dma_buf.take().map(|dma_slice| {
+                let fence = unsafe { CortexMDmaFence::new() };
+                let mut subslice = unsafe { dma_slice.take(fence) };
+                subslice.reset();
+                subslice
+            });
+
+            // Retrieve the total length of the transfer before resetting the state
+            let length = self.dma_len.get();
+            self.dma_len.set(0);
+
+            // Notify the upper-level client that the transfer is complete
+            self.client.map(|client| {
+                tx_buffer.map(|t| {
+                    client.read_write_done(t, rx_buffer, Ok(length));
+                });
+            });
+        }
+    }
+}

--- a/chips/stm32u5xx/src/spi.rs
+++ b/chips/stm32u5xx/src/spi.rs
@@ -1,0 +1,410 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+use kernel::utilities::registers::{
+    register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
+};
+use kernel::utilities::StaticRef;
+
+register_structs! {
+    pub SpiRegisters {
+        //Control register 1
+        (0x000 => cr1: ReadWrite<u32, CR1::Register>),
+        //Control register 2
+        (0x004 => cr2: ReadWrite<u32, CR2::Register>),
+        //Configuration register 1
+        (0x008 => cfg1: ReadWrite<u32, CFG1::Register>),
+        //Configuration register 2
+        (0x00C => cfg2: ReadWrite<u32, CFG2::Register>),
+        //Interrupt enable register
+        (0x010 => ier: ReadWrite<u32, IER::Register>),
+        //Status register
+        (0x014 => sr: ReadOnly<u32, SR::Register>),
+        //Interrupt/status flags clear register
+        (0x018 => ifcr: WriteOnly<u32, IFCR::Register>),
+        //Autonomous mode control register
+        (0x01C => autocr: ReadWrite<u32, AUTOCR::Register>),
+        //Transmit data register
+        (0x020 => txdr: WriteOnly<u32, TXDR::Register>),
+        (0x024 => _reserved0),
+        //Receive data register
+        (0x030 => rxdr: ReadOnly<u32, RXDR::Register>),
+        (0x034 => _reserved1),
+        //Polynomial register
+        (0x040 => crcpoly: ReadWrite<u32, CRCPOLY::Register>),
+        //Transmitter CRC register
+        (0x044 => txcrc: ReadOnly<u32, TXCRC::Register>),
+        //Receiver CRC register
+        (0x048 => rxcrc: ReadOnly<u32, RXCRC::Register>),
+        //Underrun data register
+        (0x04C => udrdr: ReadWrite<u32, UDRDR::Register>),
+        (0x050 => @END),
+    }
+}
+
+// Base addresses for SPI1, 2 and 3 in Secure Alias mode
+pub const SPI1_BASE: StaticRef<SpiRegisters> =
+    unsafe { StaticRef::new(0x5001_3000 as *const SpiRegisters) };
+// pub const SPI2_BASE: StaticRef<SpiRegisters> =
+//     unsafe { StaticRef::new(0x5000_3800 as *const SpiRegisters) }; //not used
+// pub const SPI3_BASE: StaticRef<SpiRegisters> =
+//     unsafe { StaticRef::new(0x5600_2000 as *const SpiRegisters) }; //not used
+
+register_bitfields![u32,
+    // Control Register 1
+    pub CR1 [
+        /// Locking the AF configuration of associated I/Os
+        /// 0: AF configuration is not locked
+        /// 1: AF configuration is locked
+        IOLOCK OFFSET(16) NUMBITS(1) [],
+
+        /// CRC calculation initialization pattern control for transmitter
+        /// 0: all zero pattern is applied
+        /// 1: all ones pattern is applied
+        TCRCINI OFFSET(15) NUMBITS(1) [],
+
+        /// CRC calculation initialization pattern control for receiver
+        /// 0: All zero pattern is applied
+        /// 1: All ones pattern is applied
+        RCRCINI OFFSET(14) NUMBITS(1) [],
+
+        /// Full size (33-bit or 17-bit) CRC polynomial configuration
+        /// 0: Full size (33-bit or 17-bit) CRC polynomial is not used
+        /// 1: Full size (33-bit or 17-bit) CRC polynomial is used
+        CRC33_17 OFFSET(13) NUMBITS(1) [],
+
+        /// Internal slave select signal input level
+        /// This bit has an effect only when the SSM bit is set. The value of this bit
+        /// is forced onto the peripheral NSS input internally.
+        SSI OFFSET(12) NUMBITS(1) [],
+
+        /// Rx/Tx direction at half-duplex mode
+        /// 0: SPI is receiver
+        /// 1: SPI is transmitter
+        HDDIR OFFSET(11) NUMBITS(1) [],
+
+        /// Master suspend request
+        /// In master mode, when this bit is set by software, the CSTART bit is reset
+        /// at the end of the current frame and communication is suspended.
+        CSUSP OFFSET(10) NUMBITS(1) [],
+
+        /// Master transfer start
+        /// 0: master transfer is at idle
+        /// 1: master transfer is ongoing or temporary suspended by automatic suspend
+        CSTART OFFSET(9) NUMBITS(1) [],
+
+        /// Master automatic suspension in Receive mode
+        /// 0: SPI flow/clock generation is continuous, regardless of overrun condition
+        /// 1: SPI flow is suspended temporary on RxFIFO full condition
+        MASRX OFFSET(8) NUMBITS(1) [],
+
+        /// Serial peripheral enable
+        /// 0: Serial peripheral disabled
+        /// 1: Serial peripheral enabled
+        SPE OFFSET(0) NUMBITS(1) []
+    ],
+
+    // Control Register 2
+    pub CR2 [
+        ///Number of data at current transfer
+        TSIZE OFFSET(0)  NUMBITS(16) []
+    ],
+
+    // SPI configuration register 1
+    pub CFG1 [
+        /// Bypass of the prescaler at master baud rate clock generator
+        /// 0: bypass is disabled
+        /// 1: bypass is enabled
+        BPASS OFFSET(31) NUMBITS(1) [],
+
+        /// Master baud rate prescaler setting
+        /// 000: SPI master clock/2
+        /// 001: SPI master clock/4
+        /// ...
+        /// 111: SPI master clock/256
+        MBR OFFSET(28) NUMBITS(3) [
+            Div2 = 0b000,
+            Div4 = 0b001,
+            Div8 = 0b010,
+            Div16 = 0b011,
+            Div32 = 0b100,
+            Div64 = 0b101,
+            Div128 = 0b110,
+            Div256 = 0b111
+        ],
+
+        /// Hardware CRC computation enable
+        /// 0: CRC calculation disabled
+        /// 1: CRC calculation enabled
+        CRCEN OFFSET(22) NUMBITS(1) [],
+
+        /// Length of CRC frame to be transferred and compared
+        CRCSIZE OFFSET(16) NUMBITS(5) [],
+
+        /// Tx DMA stream enable
+        /// 0: Tx DMA disabled
+        /// 1: Tx DMA enabled
+        TXDMAEN OFFSET(15) NUMBITS(1) [],
+
+        /// Rx DMA stream enable
+        /// 0: Rx-DMA disabled
+        /// 1: Rx-DMA enabled
+        RXDMAEN OFFSET(14) NUMBITS(1) [],
+
+        /// Behavior of slave transmitter at underrun condition
+        /// 0: slave sends a constant pattern defined by the user in the SPI_UDRDR register
+        /// 1: Slave repeats the last received data from master.
+        UDRCFG OFFSET(9) NUMBITS(1) [],
+
+        /// FIFO threshold level
+        /// Defines number of data frames in a single data packet.
+        FTHLV OFFSET(5) NUMBITS(4) [],
+
+        /// Number of bits in a single SPI data frame
+        DSIZE OFFSET(0) NUMBITS(5) []
+    ],
+
+    // SPI configuration register 2
+    pub CFG2 [
+        /// Alternate function GPIOs control
+        /// This bit is taken into account when SPE = 0 only.
+        /// 0: The peripheral takes no control of GPIOs while it is disabled
+        /// 1: The peripheral keeps always control of all associated GPIOs
+        AFCNTR OFFSET(31) NUMBITS(1) [],
+
+        /// NSS output management in master mode
+        /// 0: NSS is kept at active level until data transfer is complete, it becomes inactive with EOT flag
+        /// 1: SPI data frames are interleaved with NSS nonactive pulses when MIDI[3:0] > 1
+        SSOM OFFSET(30) NUMBITS(1) [],
+
+        /// NSS output enable
+        /// This bit is taken into account in master mode only
+        /// 0: NSS output is disabled and the SPI can work in multimaster configuration
+        /// 1: NSS output is enabled. The SPI cannot work in a multimaster environment.
+        SSOE OFFSET(29) NUMBITS(1) [],
+
+        /// NSS input/output polarity
+        /// 0: low level is active for NSS signal
+        /// 1: high level is active for NSS signal
+        SSIOP OFFSET(28) NUMBITS(1) [],
+
+        /// Software management of internal slave select signal input
+        /// 0: Input value of the internal slave select signal is determined by the external NSS hardware pin
+        /// 1: Input value of the internal slave select signal is determined by the SSI bit controlled by software
+        SSM OFFSET(26) NUMBITS(1) [],
+
+        // Clock polarity
+        // 0: SCK signal is at 0 when idle
+        // 1: SCK signal is at 1 when idle
+        CPOL OFFSET(25) NUMBITS(1) [],
+
+        // clock phase
+        // 0: the first clock transition is the first data capture edge
+        // 1: the second clock transition is the first data capture edge
+        CPHA OFFSET(24) NUMBITS(1) [],
+
+        // data frame format
+        // 0: MSB transmitted first
+        // 1: LSB transmitted first
+        LSBFRST OFFSET(23) NUMBITS(1) [],
+
+        // SPI master
+        // 0: SPI slave
+        // 1: SPI master
+        MASTER OFFSET(22) NUMBITS(1) [],
+
+        // Serial protocol
+        // 000: SPI Motorola
+        // 001: SPI TI
+        SP OFFSET(19) NUMBITS(3) [
+            Motorola = 0b000,
+            Ti = 0b001
+        ],
+
+        // SPI Communication Mode
+        // 00: full-duplex
+        // 01: simplex transmitter
+        // 10: simplex receiver
+        // 11: half-duplex
+        COMM OFFSET(17) NUMBITS(2) [
+            FullDuplex = 0b00,
+            SimplexTx = 0b01,
+            SimplexRx = 0b10,
+            HalfDuplex = 0b11
+        ],
+
+        // Swap functionality of MISO and MOSI pins
+        // 0: no swap
+        // 1: MOSI and MISO are swapped
+        IOSWP OFFSET(15) NUMBITS(1) [],
+
+        // RDY signal input/output polarity
+        // 0: high level of the signal means the slave is ready for communication
+        // 1: low level of the signal means the slave is ready for communication
+        RDIOP OFFSET(14) NUMBITS(1) [],
+
+        // RDY signal input/output management
+        // 0: RDY signal is defined internally fixed as permanently active (RDIOP setting has no effect)
+        // 1: RDY signal is overtaken from alternate function input (at master case) or output (at slave case)
+        RDIOM OFFSET(13) NUMBITS(1) [],
+
+        // Master Inter-Data Idleness
+        // Specifies minimum time delay (expressed in SPI clock cycles periods) inserted between two
+        // consecutive data frames in master mode.
+        MIDI OFFSET(4) NUMBITS(4) [],
+
+        // Master NSS Idleness
+        // Specifies an extra delay, expressed in number of SPI clock cycle periods, inserted
+        // additionally between active edge of NSS opening a session and the beginning of the first
+        // data frame of the session in master mode when SSOE is enabled.
+        MSSI OFFSET(0) NUMBITS(4) []
+    ],
+
+    // SPI interrupt enable register
+    pub IER [
+        // Mode Fault interrupt enable
+        MODFIE OFFSET(9) NUMBITS(1) [],
+
+        // TIFRE interrupt enable
+        TIFREIE OFFSET(8) NUMBITS(1) [],
+
+        // CRC error interrupt enable
+        CRCEIE OFFSET(7) NUMBITS(1) [],
+
+        // OVR interrupt enable
+        OVRIE OFFSET(6) NUMBITS(1) [],
+
+        // UDR interrupt enable
+        UDRIE OFFSET(5) NUMBITS(1) [],
+
+        // TXTF interrupt enable
+        TXTFIE OFFSET(4) NUMBITS(1) [],
+
+        // EOT, SUSP and TXC interrupt enable
+        EOTIE OFFSET(3) NUMBITS(1) [],
+
+        // DXP interrupt enabled
+        DXPIE OFFSET(2) NUMBITS(1) [],
+
+        // TXP interrupt enabled
+        TXPIE OFFSET(1) NUMBITS(1) [],
+
+        // RXP interrupt enabled
+        RXPIE OFFSET(0) NUMBITS(1) []
+    ],
+
+    // SPI status register
+    pub SR [
+        // number of data frames remaining in current TSIZE session
+        CTSIZE OFFSET(16) NUMBITS(16) [],
+
+        // RxFIFO word not empty
+        RXWNE OFFSET(15) NUMBITS(1) [],
+
+        // RxFIFO packing level
+        RXPLVL OFFSET(13) NUMBITS(2) [],
+
+        // TxFIFO transmission complete
+        TXC OFFSET(12) NUMBITS(1) [],
+
+        // Suspension status
+        SUSP OFFSET(11) NUMBITS(1) [],
+
+        // Mode fault
+        MODF OFFSET(9) NUMBITS(1) [],
+
+        // TI frame format error
+        TIFRE OFFSET(8) NUMBITS(1) [],
+
+        // CRC error
+        CRCE OFFSET(7) NUMBITS(1) [],
+
+        // Overrun
+        OVR OFFSET(6) NUMBITS(1) [],
+
+        // Underrun
+        UDR OFFSET(5) NUMBITS(1) [],
+
+        // Transmission transfer filled
+        TXTF OFFSET(4) NUMBITS(1) [],
+
+        // End of transfer
+        EOT OFFSET(3) NUMBITS(1) [],
+
+        // Duplex packet
+        DXP OFFSET(2) NUMBITS(1) [],
+
+        // Tx-packet space available
+        TXP OFFSET(1) NUMBITS(1) [],
+
+        // RXP: Rx-packet available
+        RXP OFFSET(0) NUMBITS(1) []
+    ],
+
+    /// SPI interrupt/status flags clear register
+    pub IFCR [
+        // Suspend flag clear
+        SUSPC OFFSET(11) NUMBITS(1) [],
+        // Mode fault flag clear
+        MODFC OFFSET(9) NUMBITS(1) [],
+        // TI frame format error flag clear
+        TIFREC OFFSET(8) NUMBITS(1) [],
+        // CRC error flag clear
+        CRCEC OFFSET(7) NUMBITS(1) [],
+        // Overrun flag clear
+        OVRC OFFSET(6) NUMBITS(1) [],
+        // Underrun flag clear
+        UDRC OFFSET(5) NUMBITS(1) [],
+        // Transmission transfer filled flag clear
+        TXTFC OFFSET(4) NUMBITS(1) [],
+        // End of transfer flag clear
+        EOTC OFFSET(3) NUMBITS(1) []
+    ],
+
+    /// SPI autonomous mode control register
+    pub AUTOCR [
+        // Hardware control of CSTART triggering enable
+        TRIGEN OFFSET(21) NUMBITS(1) [],
+        // Trigger polarity
+        TRIGPOL OFFSET(20) NUMBITS(1) [],
+        // Trigger selection
+        TRIGSEL OFFSET(16) NUMBITS(4) []
+    ],
+
+    /// SPI transmit data register
+    pub TXDR[
+        // Transmit data register
+        TXDR OFFSET(0) NUMBITS(32) []
+    ],
+
+    /// SPI receive data register
+    pub RXDR [
+        // Receive data register
+        RXDR OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI polynomial register
+    pub CRCPOLY [
+        // CRC polynomial register
+        CRCPOLY OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI transmitter CRC register
+    pub TXCRC [
+        // CRC register for transmitter
+        TXCRC OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI receiver CRC register
+    pub RXCRC [
+        // CRC register for receiver
+        RXCRC OFFSET(0) NUMBITS(32) []
+    ],
+
+    // SPI underrun data register
+    pub UDRDR [
+        // Data at slave underrun condition
+        UDRDR OFFSET(0) NUMBITS(32) []
+    ]
+];


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the spi master driver for the stm32u5xx chip as well as adding support for the Nucleo u545re_q board.


### Testing Strategy

There is no libtock-c example, so I couldn't test it from userspace, but I tested it in the kernel and used a logic analyzer to check for any bugs.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### AI Use

- [x] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR. No AI was used in 
      making of this code. Most of it was just copied from other chips, 
      modified and cross-checked with the documentation.
