### PR TITLE
STM32U5xx clock configuration

### DIFF
--- a/boards/nucleo_u545re_q/src/main.rs
+++ b/boards/nucleo_u545re_q/src/main.rs
@@ -16,7 +16,6 @@ use kernel::utilities::single_thread_value::SingleThreadValue;
 use kernel::{create_capability, static_init};
 
 use stm32u545::gpio::PinId;
-use stm32u545::rng::RNG_BASE;
 
 pub mod io;
 
@@ -186,42 +185,39 @@ unsafe fn start() -> (
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,
     >();
 
-    // Create Individual Drivers
-    let exti = static_init!(
-        stm32u545::exti::Exti<'static>,
-        stm32u545::exti::Exti::new(stm32u545::exti::EXTI_BASE)
-    );
+    // Create individual drivers
+    let exti = static_init!(stm32u545::exti::Exti<'static>, stm32u545::exti::Exti::new());
     let dma1 = static_init!(
         stm32u545::dma::Dma,
         stm32u545::dma::Dma::new(stm32u545::dma::DMA1_BASE)
     );
 
-    // Load Peripherals Bundle
+    // Create the peripheral bundle
     let periphs = static_init!(
         stm32u545::chip::Stm32u5xxDefaultPeripherals<'static>,
         stm32u545::chip::Stm32u5xxDefaultPeripherals::new(exti, dma1)
     );
 
-    let trng = static_init!(
-        stm32u545::rng::Trng<'static>,
-        stm32u545::rng::Trng::new(RNG_BASE)
-    );
-    trng.init();
-    periphs.rcc.enable_trng();
-
     // Initialize wiring (DMA, clocks)
     periphs.init();
 
-    // Board specific wiring
+    // Start the TIM2 timer, used for alarms
     periphs.tim2.start();
+
+    // Board specific wiring
     set_pin_primary_functions(periphs);
 
-    // Create an adapter for the HASH peripheral.
-    // In this way it is ensured that only one mode is used by the peripheral.
+    // Create an adapter for the HASH peripheral
+    // In this way it is ensured that only one mode is used by the peripheral
     let sha256 = static_init!(
         stm32u545::hash::sha256::Sha256Adapter<'static>,
         stm32u545::hash::sha256::Sha256Adapter::new(&periphs.hash)
     );
+
+    // Create the TRNG peripheral
+    let trng = static_init!(stm32u545::rng::Trng<'static>, stm32u545::rng::Trng::new());
+    // Note: TRNG clock routing is enabled in the RCC in `periphs.init()` above
+    trng.init();
 
     // Adapter receives callbacks from the peripheral
     let _ = periphs.hash.set_sha256_adapter(sha256);

--- a/chips/stm32u545/src/rng.rs
+++ b/chips/stm32u545/src/rng.rs
@@ -11,5 +11,3 @@ pub const RNG_NSCR_CONFIG_U545: u32 = 0x24C2;
 
 pub type Trng<'a> =
     stm32u5xx::rng::Trng<'a, RNG_CR_CONFIG_U545, RNG_HTCR_CONFIG_U545, RNG_NSCR_CONFIG_U545>;
-
-pub use stm32u5xx::rng::RNG_BASE;

--- a/chips/stm32u5xx/src/chip.rs
+++ b/chips/stm32u5xx/src/chip.rs
@@ -3,23 +3,27 @@
 // Copyright Tock Contributors 2024.
 // Copyright OxidOS Automotive 2026.
 
-use crate::adc::{self, SamplingTime as AdcSamplingTime};
-use crate::dma::{ChannelId, Dma};
-use crate::gpio;
-use crate::hash;
-use crate::nvic::{
-    ADC1_2_IRQ, EXTI0_IRQ, EXTI1_IRQ, EXTI2_IRQ, EXTI3_IRQ, EXTI4_IRQ, EXTI5_IRQ, EXTI6_IRQ,
-    EXTI7_IRQ, EXTI8_IRQ, EXTI9_IRQ, EXTI10_IRQ, EXTI11_IRQ, EXTI12_IRQ, EXTI13_IRQ, EXTI14_IRQ,
-    EXTI15_IRQ, GPDMA1_CH0_IRQ, GPDMA1_CH1_IRQ, GPDMA1_CH2_IRQ, GPDMA1_CH3_IRQ, GPDMA1_CH4_IRQ,
-    GPDMA1_CH5_IRQ, GPDMA1_CH6_IRQ, GPDMA1_CH7_IRQ, GPDMA1_CH8_IRQ, GPDMA1_CH9_IRQ,
-    GPDMA1_CH10_IRQ, GPDMA1_CH11_IRQ, GPDMA1_CH12_IRQ, GPDMA1_CH13_IRQ, GPDMA1_CH14_IRQ,
-    GPDMA1_CH15_IRQ, HASH_IRQ, TIM2_IRQ, USART1_IRQ,
+use crate::{
+    adc::{self, SamplingTime as AdcSamplingTime},
+    dac,
+    dma::{ChannelId, Dma},
+    exti, gpio, hash,
+    nvic::{
+        ADC1_2_IRQ, EXTI0_IRQ, EXTI1_IRQ, EXTI2_IRQ, EXTI3_IRQ, EXTI4_IRQ, EXTI5_IRQ, EXTI6_IRQ,
+        EXTI7_IRQ, EXTI8_IRQ, EXTI9_IRQ, EXTI10_IRQ, EXTI11_IRQ, EXTI12_IRQ, EXTI13_IRQ,
+        EXTI14_IRQ, EXTI15_IRQ, GPDMA1_CH0_IRQ, GPDMA1_CH1_IRQ, GPDMA1_CH2_IRQ, GPDMA1_CH3_IRQ,
+        GPDMA1_CH4_IRQ, GPDMA1_CH5_IRQ, GPDMA1_CH6_IRQ, GPDMA1_CH7_IRQ, GPDMA1_CH8_IRQ,
+        GPDMA1_CH9_IRQ, GPDMA1_CH10_IRQ, GPDMA1_CH11_IRQ, GPDMA1_CH12_IRQ, GPDMA1_CH13_IRQ,
+        GPDMA1_CH14_IRQ, GPDMA1_CH15_IRQ, HASH_IRQ, TIM2_IRQ, USART1_IRQ,
+    },
+    pwr::{self, VoltageScale},
+    rcc::{
+        self,
+        config::{ClockMuxConfig, RccConfig},
+        values::{AHBPrescaler, APBPrescaler, Adcdacsel, MsiRange, Sysclk, Usart1sel},
+    },
+    tim, usart,
 };
-use crate::pwr;
-use crate::rcc;
-use crate::tim;
-use crate::usart;
-use crate::{dac, exti};
 
 use core::fmt::Write;
 use kernel::deferred_call::DeferredCallClient;
@@ -48,30 +52,12 @@ pub struct Stm32u5xxDefaultPeripherals<'a> {
     pub hash: hash::hash::Hash<'a>,
 }
 
-fn enable_tim2_clock() {
-    let rcc = rcc::Rcc::new(rcc::RCC_BASE);
-    rcc.enable_tim2();
-}
-fn enable_tim3_clock() {
-    let rcc = rcc::Rcc::new(rcc::RCC_BASE);
-    rcc.enable_tim3();
-}
-
-fn enable_dac1_clock() {
-    let rcc = rcc::Rcc::new(rcc::RCC_BASE);
-    rcc.enable_dac1();
-}
-
 impl<'a> Stm32u5xxDefaultPeripherals<'a> {
     pub fn new(exti: &'a exti::Exti<'a>, dma1: &'a Dma) -> Self {
         Self {
-            rcc: rcc::Rcc::new(rcc::RCC_BASE),
-            tim2: tim::Tim2::new(tim::TIM2_BASE, enable_tim2_clock),
-            tim3: tim::Pwm::new(
-                tim::TIM3_BASE,
-                enable_tim3_clock,
-                tim::ClockSource::RESET_DEFAULT,
-            ),
+            rcc: rcc::Rcc::new(),
+            tim2: tim::Tim2::new(),
+            tim3: tim::Pwm::new(),
             usart1: usart::Usart::new(usart::USART1_BASE),
             exti,
             dma1,
@@ -80,53 +66,85 @@ impl<'a> Stm32u5xxDefaultPeripherals<'a> {
             gpio_a: gpio::Port::new(gpio::GPIO_A_BASE, exti, gpio::GpioPort::PortA),
             gpio_b: gpio::Port::new(gpio::GPIO_B_BASE, exti, gpio::GpioPort::PortB),
             gpio_c: gpio::Port::new(gpio::GPIO_C_BASE, exti, gpio::GpioPort::PortC),
-            dac: dac::Dac::new(dac::DAC_BASE, enable_dac1_clock),
-            hash: hash::hash::Hash::new(hash::regs::HASH_BASE),
+            dac: dac::Dac::new(),
+            hash: hash::hash::Hash::new(),
         }
     }
 
     pub fn init(&'static self) {
-        // Power and Wires
+        // Enable clock routing to all used peripherals
+        self.rcc.enable_tim2();
+        self.rcc.enable_tim3();
         self.rcc.enable_dma1();
         self.rcc.enable_gpioa();
+        self.rcc.enable_gpiob();
         self.rcc.enable_gpioc();
         self.rcc.enable_usart1();
         self.rcc.enable_syscfg();
         self.rcc.enable_pwr();
         self.rcc.enable_adc1();
-        self.rcc.enable_hash();
-        self.rcc.set_usart1_source_pclk();
-
-        // ADC
-        // Decided to use clock source HSI16, so that needs to be enabled in the RCC too
-        self.rcc.set_adcdacsel_source_hsi16();
-        self.rcc.enable_hsi16();
-        // For the ADC's voltage regulator to receive power, V_DDA must be validated (SVMCR.ASV) in PWR
-        self.pwr.validate_vdda();
-        // As explained in the driver, an application can't change the samplling time, so it's hardcoded here
-        self.adc1.enable(AdcSamplingTime::ClockCycles20);
-
         self.rcc.enable_dac1();
+        self.rcc.enable_hash();
+        self.rcc.enable_trng();
 
-        // Deferred Calls
+        // Select which clocks to enable, and how to configure them
+        let mut rcc_config = RccConfig {
+            msis: Some(MsiRange::Range4mhz),
+            msik: Some(MsiRange::Range4mhz),
+            hsi: true, // 16MHz oscillator enabled (for SYSCLK/ADC/DAC)
+            hse: None,
+            hsi48: false,
+            pll1: None,
+            pll2: None,
+            pll3: None,
+            sys: Sysclk::Hsi, // 16MHz system clock
+            ahb_pre: AHBPrescaler::Div1,
+            apb1_pre: APBPrescaler::Div1,
+            apb2_pre: APBPrescaler::Div1,
+            apb3_pre: APBPrescaler::Div1,
+            voltage_range: VoltageScale::Range1, // allow highest frequencies
+            mux: ClockMuxConfig::default(),
+        };
+
+        // Use HSI (16MHz) for SYSCLK, ADC and DAC
+        rcc_config.mux.adcdacsel = Adcdacsel::Hsi;
+        // Use PCLK2 for USART1 (it's the default anyways)
+        rcc_config.mux.usart1sel = Usart1sel::Pclk2;
+
+        // Initialize the RCC
+        // This returns a structure containing the effective calculated frequency for all clocks in the clock tree
+        let clocks = self.rcc.init(rcc_config, &self.pwr);
+
+        // Provide a copy of that structure to each peripheral that needs it
+        self.usart1.set_clocks(clocks);
+        self.tim2.set_clocks(clocks);
+        self.tim3.set_clocks(clocks);
+
+        // Activate the independent analog supply
+        self.pwr.validate_vdda();
+
+        // Register deferred call client for USART1
         self.usart1.register();
 
         // Link DMA to USART1
         let usart1_channel_tx = self.dma1.request_channel();
         let usart1_channel_rx = self.dma1.request_channel();
-
-        // Link DMA to HASH
-        let hash_channel = self.dma1.request_channel();
-
         if let (Some(tx), Some(rx)) = (usart1_channel_tx, usart1_channel_rx) {
             usart::Usart::set_dma(&self.usart1, self.dma1, tx, rx);
         }
 
+        // Register deferred call client for HASH
+        self.hash.register();
+
+        // Link DMA to HASH
+        let hash_channel = self.dma1.request_channel();
         if let Some(tx) = hash_channel {
             hash::hash::Hash::set_dma(&self.hash, self.dma1, tx);
         }
 
-        self.hash.register();
+        // Enable ADC
+        // As explained in the driver, an application can't change the ADC sampling time, so it's hardcoded here
+        self.adc1.enable(AdcSamplingTime::ClockCycles20);
     }
 }
 

--- a/chips/stm32u5xx/src/dac.rs
+++ b/chips/stm32u5xx/src/dac.rs
@@ -213,39 +213,30 @@ register_bitfields! [u32,
     ]
 ];
 
-pub const DAC_BASE: StaticRef<DacRegisters> =
+const DAC_BASE: StaticRef<DacRegisters> =
     unsafe { StaticRef::new(0x4602_1800 as *const DacRegisters) };
 
 /// The DAC takes in an arbitrary 12 bit number and outputs a voltage proportional to it.
 pub struct Dac {
+    /// The StaticRef pointing to the MMIO base address of the peripheral.
     registers: StaticRef<DacRegisters>,
-    enable_clock: fn(),
+    /// Bool cell that tracks whether the DAC has been initialized yet.
     initialized: Cell<bool>,
 }
 
 impl Dac {
     /// Creates a new instance of the driver.
-    ///
-    /// - `base`: The StaticRef pointing to the MMIO base address of the peripheral.
-    /// - `enable_clock`: A callback function to provide the peripheral clock via RCC.
-    /// - `initialized``: Bool cell that tracks whether the DAC has been initialized yet.
-    pub fn new(base: StaticRef<DacRegisters>, enable_clock: fn()) -> Self {
+    pub fn new() -> Self {
         Self {
-            registers: base,
-            enable_clock,
+            registers: DAC_BASE,
             initialized: Cell::new(false),
         }
-    }
-
-    fn enable_clock(&self) {
-        (self.enable_clock)();
     }
 
     /// Initialization function that only gets called on first set_value write.
     /// Because the HIL only exposes the set_value function, we have to store the initialization state as a bool to make sure we only initialize once.
     /// Configures the MODE1 register and then enables CH1 of the DAC. MODE1 is set for clarity as it set to 0 regardless and that's what we need.
     fn initialize(&self) {
-        self.enable_clock();
         self.registers.mcr.modify(MCR::MODE1::EXT_PIN_BUF_EN);
         self.registers.cr.modify(CR::EN1::SET);
         self.initialized.set(true);

--- a/chips/stm32u5xx/src/exti.rs
+++ b/chips/stm32u5xx/src/exti.rs
@@ -58,7 +58,7 @@ register_bitfields![u32,
 ];
 
 /// Base address for EXTI in Secure Alias mode.
-pub const EXTI_BASE: StaticRef<ExtiRegisters> =
+const EXTI_BASE: StaticRef<ExtiRegisters> =
     unsafe { StaticRef::new(0x56022000 as *const ExtiRegisters) };
 
 #[derive(Copy, Clone, PartialEq)]
@@ -91,9 +91,9 @@ pub struct Exti<'a> {
 
 impl<'a> Exti<'a> {
     /// Creates a new EXTI driver instance.
-    pub const fn new(base: StaticRef<ExtiRegisters>) -> Self {
+    pub const fn new() -> Self {
         Self {
-            registers: base,
+            registers: EXTI_BASE,
             clients: [const { kernel::utilities::cells::OptionalCell::empty() }; 16],
         }
     }

--- a/chips/stm32u5xx/src/hash/hash.rs
+++ b/chips/stm32u5xx/src/hash/hash.rs
@@ -11,7 +11,7 @@ use core::ops::Index;
 use crate::dma::{ChannelId, Dma};
 use crate::hash::md5::Md5Adapter;
 use crate::hash::regs::HashRegisters;
-use crate::hash::regs::{CR, IMR, SR, STR};
+use crate::hash::regs::{CR, HASH_BASE, IMR, SR, STR};
 use crate::hash::sha1::Sha1Adapter;
 use crate::hash::sha224::Sha224Adapter;
 use crate::hash::sha256::Sha256Adapter;
@@ -123,9 +123,9 @@ impl<'a> Hash<'a> {
 }
 
 impl Hash<'_> {
-    pub fn new(base: StaticRef<HashRegisters>) -> Self {
+    pub fn new() -> Self {
         Self {
-            regs: base,
+            regs: HASH_BASE,
             dma: OptionalCell::empty(),
             dma_channel: Cell::new(None),
             dma_buffer: MapCell::empty(),

--- a/chips/stm32u5xx/src/pwr.rs
+++ b/chips/stm32u5xx/src/pwr.rs
@@ -3,29 +3,73 @@
 // Copyright Tock Contributors 2026.
 
 use kernel::utilities::StaticRef;
-use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
 
 register_structs! {
     /// Power control
     PwrRegisters {
-        (0x000 => _reserved),
+        (0x000 => _reserved1),
+        /// PWR voltage scaling register
+        (0x00C => pwr_vosr: ReadWrite<u32, PWR_VOSR::Register>),
         /// PWR supply voltage monitoring control register
         (0x010 => pwr_svmcr: ReadWrite<u32, PWR_SVMCR::Register>),
-        (0x014 => @END),
+        (0x014 => _reserved2),
+        /// PWR supply voltage monitoring status registe
+        (0x03C => pwr_svmsr: ReadWrite<u32, PWR_SVMSR::Register>),
+        (0x040 => @END),
     }
 }
 register_bitfields![u32,
+    PWR_VOSR [
+        BOOSTEN OFFSET(18) NUMBITS(1) [],
+        VOS OFFSET(16) NUMBITS(2) [
+            RANGE4 = 0,
+            RANGE3 = 1,
+            RANGE2 = 2,
+            RANGE1 = 3,
+        ],
+        VOSRDY OFFSET(15) NUMBITS(1) [],
+        BOOSTRDY OFFSET(14) NUMBITS(1) []
+    ],
     PWR_SVMCR [
         // This bit is used to validate the VDDA supply for electrical and logical isolation purpose.
         // Setting this bit is mandatory to use the analog peripherals.
         // If VDDA is not always present in the application, the VDDA voltage monitor can be used to determine whether this supply is ready or not.
         /// VDDA independent analog supply valid
-        ASV OFFSET(30) NUMBITS(1) []
+        ASV OFFSET(30) NUMBITS(1) [],
+        // This bit is used to validate the VDDIO2 supply for electrical and logical isolation purpose.
+        // Setting this bit is mandatory to use PG[15:2]. If VDDIO2 is not always present in the application, the VDDIO2 voltage monitor can
+        // be used to determine whether this supply is ready or not.
+        /// VDDIO2 independent I/Os supply valid
+        IO2SV OFFSET(29) NUMBITS(1) [],
+        // This bit is used to validate the VDDUSB supply for electrical and logical isolation purpose.
+        // Setting this bit is mandatory to use the USB/OTG_FS/OTG_HS.
+        // If VDDUSB is not always present in the application, the VDDUSB voltage monitor can be used to determine whether this supply is ready or not.
+        /// VDDUSB independent USB supply valid
+        USV OFFSET(28) NUMBITS(1) [],
+        /// VDDA independent analog supply voltage monitor 1 enable (1.6 V threshold)
+        AVM1EN OFFSET(26) NUMBITS(1) []
+    ],
+    PWR_SVMSR [
+        /// VDDA ready versus 1.6V voltage monitor
+        VDDA1RDY OFFSET(26) NUMBITS(1) []
     ],
 ];
 const PWR_BASE: StaticRef<PwrRegisters> =
     unsafe { StaticRef::new(0x46020800 as *const PwrRegisters) };
+
+#[derive(Clone, Copy)]
+pub enum VoltageScale {
+    /// Range 4 (lowest power)
+    Range4,
+    /// Range 3
+    Range3,
+    /// Range 2
+    Range2,
+    /// Range 1 (highest frequency). This value cannot be written when VCOREMEN = 1 in TAMP_OR register.
+    Range1,
+}
 
 pub struct Pwr {
     registers: StaticRef<PwrRegisters>,
@@ -39,6 +83,32 @@ impl Pwr {
     }
 
     pub fn validate_vdda(&self) {
+        self.registers.pwr_svmcr.modify(PWR_SVMCR::AVM1EN::SET);
+        while !self.registers.pwr_svmsr.is_set(PWR_SVMSR::VDDA1RDY) {}
         self.registers.pwr_svmcr.modify(PWR_SVMCR::ASV::SET);
+    }
+
+    pub fn validate_vddio2(&self) {
+        self.registers.pwr_svmcr.modify(PWR_SVMCR::IO2SV::SET);
+    }
+
+    pub fn validate_vddusb(&self) {
+        self.registers.pwr_svmcr.modify(PWR_SVMCR::USV::SET);
+    }
+
+    pub fn set_voltage_scaling(&self, range: VoltageScale) {
+        self.registers.pwr_vosr.modify(match range {
+            VoltageScale::Range1 => PWR_VOSR::VOS::RANGE1,
+            VoltageScale::Range2 => PWR_VOSR::VOS::RANGE2,
+            VoltageScale::Range3 => PWR_VOSR::VOS::RANGE3,
+            VoltageScale::Range4 => PWR_VOSR::VOS::RANGE4,
+        });
+
+        while !self.registers.pwr_vosr.is_set(PWR_VOSR::VOSRDY) {}
+    }
+
+    pub fn enable_epod_booster(&self) {
+        self.registers.pwr_vosr.modify(PWR_VOSR::BOOSTEN::SET);
+        while !self.registers.pwr_vosr.is_set(PWR_VOSR::BOOSTRDY) {}
     }
 }

--- a/chips/stm32u5xx/src/rcc.rs
+++ b/chips/stm32u5xx/src/rcc.rs
@@ -4,43 +4,202 @@
 // Copyright OxidOS Automotive 2026.
 
 use kernel::utilities::StaticRef;
-use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
 
+// The PWR peripheral is needed for setting the voltage scale and enabling the EPOD booster
+use crate::pwr::{Pwr, VoltageScale};
+
+// Configuration structures and enumerations
+pub mod config;
+use config::{HseMode, Pll, PllInput, RccConfig};
+
+// Enumerations for some RCC fields
+pub mod values;
+use values::{
+    Adcdacsel, Adfsel, Dacsel, Fdcansel, I2c3sel, I2csel, Iclksel, Lptim2sel, Lptimsel, Lpusartsel,
+    MsiRange, Octospisel, PllDiv, PllMboost, PllSource, Pllrge, Rngsel, Rtcsel, Saessel, Saisel,
+    Sdmmcsel, Spi1sel, Spi2sel, Spi3sel, Sysclk, Usart1sel, Usartsel,
+};
+
+// Helper for frequencies
+pub mod hertz;
+use hertz::Hertz;
+
+/// All clock frequencies
+#[derive(Copy, Clone)]
+pub struct Clocks {
+    pub sys: Hertz,
+    pub hclk1: Hertz,
+    pub hclk2: Hertz,
+    pub hclk3: Hertz,
+    pub pclk1: Hertz,
+    pub pclk2: Hertz,
+    pub pclk3: Hertz,
+    pub pclk1_tim: Hertz,
+    pub pclk2_tim: Hertz,
+    pub msik: Option<Hertz>,
+    pub hsi48: Option<Hertz>,
+    pub hse: Option<Hertz>,
+    pub hsi: Option<Hertz>,
+    pub pll1_p: Option<Hertz>,
+    pub pll1_q: Option<Hertz>,
+    pub pll1_r: Option<Hertz>,
+    pub pll2_p: Option<Hertz>,
+    pub pll2_q: Option<Hertz>,
+    pub pll2_r: Option<Hertz>,
+    pub pll3_p: Option<Hertz>,
+    pub pll3_q: Option<Hertz>,
+    pub pll3_r: Option<Hertz>,
+}
+
+// Registers and fields
 register_structs! {
     pub RccRegisters {
         /// Control register
         (0x000 => cr: ReadWrite<u32, CR::Register>),
-        (0x004 => _reserved0: [u32; 33]),
+        (0x004 => _reserved0),
+        (0x008 => icscr1: ReadWrite<u32, ICSCR1::Register>),
+        (0x00C => _reserved1),
+        /// Clock configuration register 1
+        (0x01C => cfgr1: ReadWrite<u32, CFGR1::Register>),
+        /// Clock configuration register 2
+        (0x020 => cfgr2: ReadWrite<u32, CFGR2::Register>),
+        /// Clock configuration register 2
+        (0x024 => cfgr3: ReadWrite<u32, CFGR3::Register>),
+        /// RCC PLL1 configuration register
+        (0x028 => pll1cfgr: ReadWrite<u32, PLLxCFGR::Register>),
+        /// RCC PLL2 configuration register
+        (0x02C => pll2cfgr: ReadWrite<u32, PLLxCFGR::Register>),
+        /// RCC PLL3 configuration register
+        (0x030 => pll3cfgr: ReadWrite<u32, PLLxCFGR::Register>),
+        /// RCC PLL1 dividers configuration register
+        (0x034 => pll1divr: ReadWrite<u32, PLLxDIVR::Register>),
+        (0x038 => _reserved2),
+        /// RCC PLL2 dividers configuration register
+        (0x03C => pll2divr: ReadWrite<u32, PLLxDIVR::Register>),
+        (0x040 => _reserved3),
+        /// RCC PLL3 dividers configuration register
+        (0x044 => pll3divr: ReadWrite<u32, PLLxDIVR::Register>),
+        (0x048 => _reserved4),
         /// AHB1 peripheral clock enable register
         (0x088 => ahb1enr: ReadWrite<u32, AHB1ENR::Register>),
         /// AHB2 peripheral clock enable register 1
         (0x08C => ahb2enr1: ReadWrite<u32, AHB2ENR1::Register>),
-        (0x090 => _reserved1: [u32; 1]),
+        (0x090 => _reserved5: [u32; 1]),
         /// AHB3 peripheral clock enable register
         (0x094 => ahb3enr: ReadWrite<u32, AHB3ENR::Register>),
-        (0x098 => _reserved2: [u32; 1]),
+        (0x098 => _reserved6: [u32; 1]),
         /// APB1 peripheral clock enable register 1
         (0x09C => apb1enr1: ReadWrite<u32, APB1ENR1::Register>),
-        (0x0A0 => _reserved3: [u32; 1]), //this would be APB1ENR2, but unused for now
+        (0x0A0 => _reserved7: [u32; 1]), //this would be APB1ENR2, but unused for now
         /// APB2 peripheral clock enable register
         (0x0A4 => apb2enr: ReadWrite<u32, APB2ENR::Register>),
         /// APB3 peripheral clock enable register
         (0x0A8 => apb3enr: ReadWrite<u32, APB3ENR::Register>),
-        (0x0AC => _reserved4: [u32; 13]),
+        (0x0AC => _reserved8: [u32; 13]),
         /// Peripherals independent clock configuration register 1
         (0x0E0 => ccipr1: ReadWrite<u32, CCIPR1::Register>),
-        (0x0E4 => ccipr2: ReadWrite<u32, CCIPR1::Register>),
+        /// Peripherals independent clock configuration register 2
+        (0x0E4 => ccipr2: ReadWrite<u32, CCIPR2::Register>),
         /// Peripherals independent clock configuration register 3
         (0x0E8 => ccipr3: ReadWrite<u32, CCIPR3::Register>),
-        (0x0EC => @END),
+        (0x0EC => _reserved9),
+        /// RCC backup domain control registe
+        (0x0F0 => bdcr: ReadWrite<u32, BDCR::Register>),
+        (0x0F4 => @END),
     }
 }
-
 register_bitfields![u32,
     pub CR [
+        MSISON OFFSET(0) NUMBITS(1) [],
+        MSISRDY OFFSET(2) NUMBITS(1) [],
+        MSIPLLEN OFFSET(3) NUMBITS(1) [],
+        MSIKON OFFSET(4) NUMBITS(1) [],
+        MSIKRDY OFFSET(5) NUMBITS(1) [],
+        MSIPLLFAST OFFSET(7) NUMBITS(1) [],
         HSION OFFSET(8) NUMBITS(1) [],
-        HSIRDY OFFSET(10) NUMBITS(1) []
+        HSIRDY OFFSET(10) NUMBITS(1) [],
+        HSI48ON OFFSET(12) NUMBITS(1) [],
+        HSI48RDY OFFSET(13) NUMBITS(1) [],
+        HSEON OFFSET(16) NUMBITS(1) [],
+        HSERDY OFFSET(17) NUMBITS(1) [],
+        HSEBYP OFFSET(18) NUMBITS(1) [],
+        HSEEXT OFFSET(20) NUMBITS(1) [
+            ANALOG = 0,
+            DIGITAL = 1,
+        ],
+        PLL1ON OFFSET(24) NUMBITS(1) [],
+        PLL1RDY OFFSET(25) NUMBITS(1) [],
+        PLL2ON OFFSET(26) NUMBITS(1) [],
+        PLL2RDY OFFSET(27) NUMBITS(1) [],
+        PLL3ON OFFSET(28) NUMBITS(1) [],
+        PLL3RDY OFFSET(29) NUMBITS(1) [],
+    ],
+    pub ICSCR1 [
+        MSISRANGE OFFSET(28) NUMBITS(4) [],
+        MSIKRANGE OFFSET(24) NUMBITS(4) [],
+        MSIRGSEL OFFSET(23) NUMBITS(1) [
+            CSR = 0,
+            ICSCR1 = 1,
+        ],
+    ],
+    pub CFGR1 [
+        SW OFFSET(0) NUMBITS(2) [],
+        SWS OFFSET(2) NUMBITS(2) [],
+    ],
+    pub CFGR2 [
+        HPRE OFFSET(0) NUMBITS(4) [
+            DIV1 = 0,
+            DIV2 = 0b1000,
+            DIV4 = 0b1001,
+            DIV8 = 0b1010,
+            DIV16 = 0b1011,
+            // no DIV32
+            DIV64 = 0b1100,
+            DIV128 = 0b1101,
+            DIV256 = 0b1110,
+            DIV512 = 0b1111,
+        ],
+        PPRE1 OFFSET(4) NUMBITS(3) [
+            DIV1 = 0,
+            DIV2 = 0b100,
+            DIV4 = 0b101,
+            DIV8 = 0b110,
+            DIV16 = 0b111,
+        ],
+        PPRE2 OFFSET(8) NUMBITS(3) [
+            DIV1 = 0,
+            DIV2 = 0b100,
+            DIV4 = 0b101,
+            DIV8 = 0b110,
+            DIV16 = 0b111,
+        ],
+    ],
+    pub CFGR3 [
+        PPRE3 OFFSET(4) NUMBITS(3) [
+            DIV1 = 0,
+            DIV2 = 0b100,
+            DIV4 = 0b101,
+            DIV8 = 0b110,
+            DIV16 = 0b111,
+        ],
+    ],
+    pub PLLxCFGR [
+        PLLxREN OFFSET(18) NUMBITS(1) [],
+        PLLxQEN OFFSET(17) NUMBITS(1) [],
+        PLLxPEN OFFSET(16) NUMBITS(1) [],
+        PLLxMBOOST OFFSET(12) NUMBITS(4) [],
+        PLLxM OFFSET(8) NUMBITS(4) [],
+        PLLxFRACEN OFFSET(4) NUMBITS(1) [],
+        PLLxRGE OFFSET(2) NUMBITS(2) [],
+        PLLxSRC OFFSET(0) NUMBITS(2) []
+    ],
+    pub PLLxDIVR [
+        PLLxR OFFSET(24) NUMBITS(7) [],
+        PLLxQ OFFSET(16) NUMBITS(7) [],
+        PLLxP OFFSET(9) NUMBITS(7) [],
+        PLLxN OFFSET(0) NUMBITS(9) []
     ],
     pub AHB1ENR [
         GPDMA1EN OFFSET(0) NUMBITS(1) []
@@ -62,7 +221,7 @@ register_bitfields![u32,
     ],
     pub AHB3ENR [
         PWREN OFFSET(2) NUMBITS(1) [],
-        DAC1EN OFFSET(6) NUMBITS(1) [],
+        DAC1EN OFFSET(6) NUMBITS(1) []
     ],
     pub APB1ENR1 [
         TIM2EN OFFSET(0) NUMBITS(1) [],
@@ -75,31 +234,42 @@ register_bitfields![u32,
         SYSCFGEN OFFSET(1) NUMBITS(1) []
     ],
     pub CCIPR1 [
-        USART1SEL OFFSET(0) NUMBITS(2) [
-            PCLK = 0,
-            SYSCLK = 1,
-            HSI16 = 2,
-            LSE = 3
-        ]
+        ICLKSEL OFFSET(26) NUMBITS(2) [],
+        FDCAN1SEL OFFSET(24) NUMBITS(2) [],
+        SPI1SEL OFFSET(20) NUMBITS(2) [],
+        LPTIM2SEL OFFSET(18) NUMBITS(2) [],
+        SPI2SEL OFFSET(16) NUMBITS(2) [],
+        I2C4SEL OFFSET(14) NUMBITS(2) [],
+        I2C2SEL OFFSET(12) NUMBITS(2) [],
+        I2C1SEL OFFSET(10) NUMBITS(2) [],
+        UART5SEL OFFSET(8) NUMBITS(2) [],
+        UART4SEL OFFSET(6) NUMBITS(2) [],
+        USART3SEL OFFSET(4) NUMBITS(2) [],
+        USART2SEL OFFSET(2) NUMBITS(2) [],
+        USART1SEL OFFSET(0) NUMBITS(2) []
+    ],
+    pub CCIPR2 [
+        OCTOSPISEL OFFSET(20) NUMBITS(2) [],
+        SDMMCSEL OFFSET(14) NUMBITS(1) [],
+        RNGSEL OFFSET(12) NUMBITS(2) [],
+        SAESSEL OFFSET(11) NUMBITS(1) [],
+        SAI1SEL OFFSET(5) NUMBITS(3) []
     ],
     pub CCIPR3 [
-        ADCDACSEL OFFSET(12) NUMBITS(3) [
-            HCLK = 0,
-            SYSCLK = 1,
-            PLL2_R_CK = 2,
-            HSE = 3,
-            HSI16 = 4,
-            MSIK = 5
-        ],
-        DAC1SEL OFFSET(15) NUMBITS(1) [
-            LSE = 0,
-            LSI = 1
-        ]
+        ADF1SEL OFFSET(16) NUMBITS(3) [],
+        DAC1SEL OFFSET(15) NUMBITS(1) [],
+        ADCDACSEL OFFSET(12) NUMBITS(3) [],
+        LPTIM1SEL OFFSET(10) NUMBITS(2) [],
+        I2C3SEL OFFSET(6) NUMBITS(2) [],
+        SPI3SEL OFFSET(3) NUMBITS(2) [],
+        LPUART1SEL OFFSET(0) NUMBITS(3) []
+    ],
+    pub BDCR [
+        RTCSEL OFFSET(8) NUMBITS(2) []
     ],
 ];
-
 /// Base address for RCC in Nonsecure mode
-pub const RCC_BASE: StaticRef<RccRegisters> =
+const RCC_BASE: StaticRef<RccRegisters> =
     unsafe { StaticRef::new(0x46020C00 as *const RccRegisters) };
 
 pub struct Rcc {
@@ -107,70 +277,524 @@ pub struct Rcc {
 }
 
 impl Rcc {
-    pub const fn new(base: StaticRef<RccRegisters>) -> Self {
-        Self { registers: base }
+    pub const fn new() -> Self {
+        Self {
+            registers: RCC_BASE,
+        }
     }
 
-    pub fn enable_dma1(&self) {
-        self.registers.ahb1enr.modify(AHB1ENR::GPDMA1EN::SET);
+    /// Configure and start all necessary clocks
+    // Adapted from embassy-rs/embassy/embassy-stm32/src/rcc/u5.rs
+    pub fn init(&self, config: RccConfig, pwr: &Pwr) -> Clocks {
+        // Configure the clock to a safe default state before starting configuration:
+        // power range 1 (most powerful), HSI as SYSCLK source (16MHz)
+        pwr.set_voltage_scaling(VoltageScale::Range1);
+        self.enable_hsi16();
+        self.set_sysclk_source(Sysclk::Hsi);
+
+        let msis = config.msis.map(|range| {
+            // Check MSI output per RM0456 § 11.4.10
+            if let VoltageScale::Range4 = config.voltage_range {
+                assert!(Self::msirange_to_hertz(range).0 <= 24_000_000);
+            }
+
+            // RM0456 § 11.8.2: spin until MSIS is off or MSIS is ready before setting its range
+            loop {
+                let cr = self.registers.cr.extract();
+                if !cr.is_set(CR::MSISON) || cr.is_set(CR::MSISRDY) {
+                    break;
+                }
+            }
+
+            self.registers
+                .icscr1
+                .modify(ICSCR1::MSISRANGE.val(range as u32) + ICSCR1::MSIRGSEL::ICSCR1);
+
+            self.registers
+                .cr
+                .write(CR::MSIPLLEN::CLEAR + CR::MSISON::SET);
+
+            while !self.registers.cr.is_set(CR::MSISRDY) {}
+
+            Self::msirange_to_hertz(range)
+        });
+
+        let msik = config.msik.map(|range| {
+            if let VoltageScale::Range4 = config.voltage_range {
+                assert!(Self::msirange_to_hertz(range).0 <= 24_000_000);
+            }
+
+            loop {
+                let cr = self.registers.cr.extract();
+                if !cr.is_set(CR::MSIKON) || cr.is_set(CR::MSIKRDY) {
+                    break;
+                }
+            }
+
+            self.registers
+                .icscr1
+                .modify(ICSCR1::MSIKRANGE.val(range as u32) + ICSCR1::MSIRGSEL::ICSCR1);
+
+            self.registers.cr.modify(CR::MSIKON::SET);
+
+            while !self.registers.cr.is_set(CR::MSIKRDY) {}
+
+            Self::msirange_to_hertz(range)
+        });
+
+        let hsi = config.hsi.then_some(Hertz(16_000_000));
+
+        let hse = config.hse.map(|hse| {
+            // Check frequency limits per RM456 § 11.4.10
+            match config.voltage_range {
+                VoltageScale::Range1 | VoltageScale::Range2 | VoltageScale::Range3 => {
+                    assert!(hse.freq.0 <= 50_000_000);
+                }
+                VoltageScale::Range4 => {
+                    assert!(hse.freq.0 <= 25_000_000);
+                }
+            }
+
+            // Enable HSE and wait for it to stabilize
+            self.registers.cr.modify(
+                CR::HSEON::SET
+                    + match hse.mode {
+                        HseMode::Oscillator => CR::HSEBYP::CLEAR,
+                        _ => CR::HSEBYP::SET,
+                    }
+                    + match hse.mode {
+                        HseMode::Oscillator | HseMode::Bypass => CR::HSEEXT::ANALOG,
+                        HseMode::BypassDigital => CR::HSEEXT::DIGITAL,
+                    },
+            );
+
+            while !self.registers.cr.is_set(CR::HSERDY) {}
+
+            hse.freq
+        });
+
+        let hsi48 = if config.hsi48 {
+            self.enable_hsi48();
+            Some(Hertz(48_000_000))
+        } else {
+            None
+        };
+
+        let pll_input = PllInput {
+            hsi,
+            hse,
+            msi: msis,
+        };
+        let pll1 = config.pll1.map_or_else(
+            || {
+                self.change_pll_enable(PllInstance::Pll1, false);
+                PllOutput::default()
+            },
+            |c| self.init_pll(PllInstance::Pll1, Some(c), &pll_input, config.voltage_range),
+        );
+        let pll2 = config.pll2.map_or_else(
+            || {
+                self.change_pll_enable(PllInstance::Pll2, false);
+                PllOutput::default()
+            },
+            |c| self.init_pll(PllInstance::Pll2, Some(c), &pll_input, config.voltage_range),
+        );
+        let pll3 = config.pll3.map_or_else(
+            || {
+                self.change_pll_enable(PllInstance::Pll3, false);
+                PllOutput::default()
+            },
+            |c| self.init_pll(PllInstance::Pll3, Some(c), &pll_input, config.voltage_range),
+        );
+
+        // Verify that sysclk is valid before attempting to change the clock source
+        // This ensures that, even in case of an error, the clock remains in a safe state
+        let sys_clk = match config.sys {
+            Sysclk::Hse => hse.unwrap(),
+            Sysclk::Hsi => hsi.unwrap(),
+            Sysclk::Msis => msis.unwrap(),
+            Sysclk::Pll1R => pll1.r.unwrap(),
+        };
+
+        let hclk = sys_clk / config.ahb_pre;
+
+        let hclk_max = match config.voltage_range {
+            VoltageScale::Range1 => Hertz::mhz(160),
+            VoltageScale::Range2 => Hertz::mhz(110),
+            VoltageScale::Range3 => Hertz::mhz(55),
+            VoltageScale::Range4 => Hertz::mhz(25),
+        };
+        assert!(hclk <= hclk_max);
+
+        // If needed, enable the EPOD booster to reach the target clock speed, per § 10.5.4
+        if sys_clk >= Hertz::mhz(55) {
+            pwr.enable_epod_booster();
+        }
+
+        // Set the requested power mode
+        pwr.set_voltage_scaling(config.voltage_range);
+
+        // Configure the bus prescalers
+        self.registers.cfgr2.modify(
+            CFGR2::HPRE.val(config.ahb_pre as u32)
+                + CFGR2::PPRE1.val(config.apb1_pre as u32)
+                + CFGR2::PPRE2.val(config.apb2_pre as u32),
+        );
+        self.registers
+            .cfgr3
+            .modify(CFGR3::PPRE3.val(config.apb3_pre as u32));
+
+        // Switch the clock source
+        self.set_sysclk_source(config.sys);
+
+        let (pclk1, pclk1_tim) = Self::calc_pclk(hclk, config.apb1_pre);
+        let (pclk2, pclk2_tim) = Self::calc_pclk(hclk, config.apb2_pre);
+        let (pclk3, _) = Self::calc_pclk(hclk, config.apb3_pre);
+
+        // Disable HSI if not used
+        if !config.hsi {
+            self.registers.cr.modify(CR::HSION::CLEAR);
+        }
+
+        // Disable HSI48 if not used
+        if !config.hsi48 {
+            self.registers.cr.modify(CR::HSI48ON::CLEAR);
+        }
+
+        // Set clock sources according to the mux configuration
+        config.mux.init(self);
+
+        // Return a structure containing all effective clock frequencies
+        Clocks {
+            sys: sys_clk,
+            hclk1: hclk,
+            hclk2: hclk,
+            hclk3: hclk,
+            pclk1,
+            pclk2,
+            pclk3,
+            pclk1_tim,
+            pclk2_tim,
+            msik,
+            hsi48,
+            hse,
+            hsi,
+            pll1_p: pll1.p,
+            pll1_q: pll1.q,
+            pll1_r: pll1.r,
+            pll2_p: pll2.p,
+            pll2_q: pll2.q,
+            pll2_r: pll2.r,
+            pll3_p: pll3.p,
+            pll3_q: pll3.q,
+            pll3_r: pll3.r,
+        }
     }
 
-    pub fn enable_gpioa(&self) {
-        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOAEN::SET);
-    }
-
-    pub fn enable_gpioc(&self) {
-        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOCEN::SET);
-    }
-
-    pub fn enable_usart1(&self) {
-        self.registers.apb2enr.modify(APB2ENR::USART1EN::SET);
-    }
-
-    pub fn enable_tim2(&self) {
-        self.registers.apb1enr1.modify(APB1ENR1::TIM2EN::SET);
-    }
-
-    pub fn enable_tim3(&self) {
-        self.registers.apb1enr1.modify(APB1ENR1::TIM3EN::SET);
-    }
-
-    pub fn enable_syscfg(&self) {
-        self.registers.apb3enr.modify(APB3ENR::SYSCFGEN::SET);
-    }
-
-    pub fn enable_pwr(&self) {
-        self.registers.ahb3enr.modify(AHB3ENR::PWREN::SET);
-    }
-
-    pub fn enable_hsi16(&self) {
+    /// Start the 16MHz internal oscillator
+    fn enable_hsi16(&self) {
         self.registers.cr.modify(CR::HSION::SET);
 
         // Wait for oscillator ready
         while !self.registers.cr.is_set(CR::HSIRDY) {}
     }
 
+    /// Start the 48MHz internal oscillator
+    fn enable_hsi48(&self) {
+        self.registers.cr.modify(CR::HSI48ON::SET);
+
+        // Wait for oscillator ready
+        while !self.registers.cr.is_set(CR::HSI48RDY) {}
+    }
+
+    /// Change the clock source for SYSCLK
+    fn set_sysclk_source(&self, clk: Sysclk) {
+        self.registers.cfgr1.modify(CFGR1::SW.val(clk as u32));
+
+        // Wait for the value in the "status" register to match what we set
+        while self.registers.cfgr1.read(CFGR1::SWS) != clk as u32 {}
+    }
+
+    /// Enable or disable a PLL
+    fn change_pll_enable(&self, instance: PllInstance, enabled: bool) {
+        self.registers.cr.modify(match instance {
+            PllInstance::Pll1 => CR::PLL1ON.val(enabled as u32),
+            PllInstance::Pll2 => CR::PLL2ON.val(enabled as u32),
+            PllInstance::Pll3 => CR::PLL3ON.val(enabled as u32),
+        });
+
+        while self.registers.cr.is_set(match instance {
+            PllInstance::Pll1 => CR::PLL1RDY,
+            PllInstance::Pll2 => CR::PLL2RDY,
+            PllInstance::Pll3 => CR::PLL3RDY,
+        }) != enabled
+        {}
+    }
+
+    /// Configure and start a PLL
+    // Adapted from embassy-rs/embassy/embassy-stm32/src/rcc/u5.rs
+    fn init_pll(
+        &self,
+        instance: PllInstance,
+        config: Option<Pll>,
+        input: &PllInput,
+        voltage_range: VoltageScale,
+    ) -> PllOutput {
+        // Disable PLL
+        self.change_pll_enable(instance, false);
+
+        let Some(pll) = config else {
+            return PllOutput::default();
+        };
+
+        let src_freq = match pll.source {
+            PllSource::Disable => panic!("must not select PLL source as DISABLE"),
+            PllSource::Hse => input.hse.unwrap(),
+            PllSource::Hsi => input.hsi.unwrap(),
+            PllSource::Msis => input.msi.unwrap(),
+        };
+
+        // Calculate the reference clock, which is the source divided by m
+        let ref_freq = src_freq / pll.prediv;
+
+        // Check limits per RM0456 § 11.4.6
+        assert!(Hertz::mhz(4) <= ref_freq && ref_freq <= Hertz::mhz(16));
+
+        // Check PLL clocks per RM0456 § 11.4.10
+        let (vco_min, vco_max, out_max) = match voltage_range {
+            VoltageScale::Range1 => (Hertz::mhz(128), Hertz::mhz(544), Hertz::mhz(208)),
+            VoltageScale::Range2 => (Hertz::mhz(128), Hertz::mhz(544), Hertz::mhz(110)),
+            VoltageScale::Range3 => (Hertz::mhz(128), Hertz::mhz(330), Hertz::mhz(55)),
+            VoltageScale::Range4 => panic!("PLL is unavailable in voltage range 4"),
+        };
+
+        // Calculate the PLL VCO clock
+        let vco_freq = ref_freq * pll.mul;
+        assert!(vco_freq >= vco_min && vco_freq <= vco_max);
+
+        // Calculate output clocks
+        let p = pll.divp.map(|div| vco_freq / div);
+        let q = pll.divq.map(|div| vco_freq / div);
+        let r = pll.divr.map(|div| vco_freq / div);
+        for freq in [p, q, r] {
+            if let Some(freq) = freq {
+                assert!(freq <= out_max);
+            }
+        }
+
+        let divr = match instance {
+            PllInstance::Pll1 => &self.registers.pll1divr,
+            PllInstance::Pll2 => &self.registers.pll2divr,
+            PllInstance::Pll3 => &self.registers.pll3divr,
+        };
+        divr.write(
+            PLLxDIVR::PLLxN.val(pll.mul as u32)
+                + PLLxDIVR::PLLxP.val(pll.divp.unwrap_or(PllDiv::Div1) as u32)
+                + PLLxDIVR::PLLxQ.val(pll.divq.unwrap_or(PllDiv::Div1) as u32)
+                + PLLxDIVR::PLLxR.val(pll.divr.unwrap_or(PllDiv::Div1) as u32),
+        );
+
+        let input_range = match ref_freq.0 {
+            ..=8_000_000 => Pllrge::Freq4to8mhz,
+            _ => Pllrge::Freq8to16mhz,
+        };
+
+        let (pllxcfgr, mboost) = match instance {
+            PllInstance::Pll1 => {
+                // § 10.5.4: if we're targeting >= 55 MHz, we must configure PLL1MBOOST to a prescaler
+                // value that results in an output between 4 and 16 MHz for the PWR EPOD boost
+                let mboost = if r.unwrap() >= Hertz::mhz(55) {
+                    // source_clk can be up to 50 MHz, so there's just a few cases:
+                    match src_freq.0 {
+                        ..=16_000_000 => PllMboost::Div1, // Bypass, giving EPOD 4-16 MHz
+                        16_000_001..=32_000_000 => PllMboost::Div2, // Divide by 2, giving EPOD 8-16 MHz
+                        _ => PllMboost::Div4, // Divide by 4, giving EPOD 8-12.5 MHz
+                    }
+                } else {
+                    PllMboost::Div1
+                };
+
+                (&self.registers.pll1cfgr, mboost)
+            }
+            PllInstance::Pll2 => (&self.registers.pll2cfgr, PllMboost::Div1),
+            PllInstance::Pll3 => (&self.registers.pll3cfgr, PllMboost::Div1),
+        };
+
+        pllxcfgr.write(
+            PLLxCFGR::PLLxMBOOST.val(mboost as u32)
+                + PLLxCFGR::PLLxPEN.val(pll.divp.is_some() as u32)
+                + PLLxCFGR::PLLxQEN.val(pll.divq.is_some() as u32)
+                + PLLxCFGR::PLLxREN.val(pll.divr.is_some() as u32)
+                + PLLxCFGR::PLLxM.val(pll.prediv as u32)
+                + PLLxCFGR::PLLxSRC.val(pll.prediv as u32)
+                + PLLxCFGR::PLLxSRC.val(pll.source as u32)
+                + PLLxCFGR::PLLxRGE.val(input_range as u32),
+        );
+
+        // Enable PLL
+        self.change_pll_enable(instance, true);
+
+        PllOutput { p, q, r }
+    }
+
+    /// Set the clock source for various peripherals
+    pub fn set_clock_sources(
+        &self,
+        // BDCR
+        rtcsel: Rtcsel,
+        // CCIPR1
+        fdcansel: Fdcansel,
+        i2c1sel: I2csel,
+        i2c2sel: I2csel,
+        i2c4sel: I2csel,
+        iclksel: Iclksel,
+        lptim2sel: Lptim2sel,
+        spi1sel: Spi1sel,
+        spi2sel: Spi2sel,
+        uart4sel: Usartsel,
+        uart5sel: Usartsel,
+        usart1sel: Usart1sel,
+        usart3sel: Usartsel,
+        // CCIPR2
+        octospisel: Octospisel,
+        rngsel: Rngsel,
+        saessel: Saessel,
+        sai1sel: Saisel,
+        sdmmcsel: Sdmmcsel,
+        // CCIPR3
+        adcdacsel: Adcdacsel,
+        adf1sel: Adfsel,
+        dac1sel: Dacsel,
+        i2c3sel: I2c3sel,
+        lptim1sel: Lptimsel,
+        lpuart1sel: Lpusartsel,
+        spi3sel: Spi3sel,
+    ) {
+        self.registers.bdcr.modify(BDCR::RTCSEL.val(rtcsel as u32));
+
+        // There is no USART2 on STM32U535/545
+        self.registers.ccipr1.modify(
+            CCIPR1::FDCAN1SEL.val(fdcansel as u32)
+                + CCIPR1::I2C1SEL.val(i2c1sel as u32)
+                + CCIPR1::I2C2SEL.val(i2c2sel as u32)
+                + CCIPR1::I2C4SEL.val(i2c4sel as u32)
+                + CCIPR1::ICLKSEL.val(iclksel as u32)
+                + CCIPR1::LPTIM2SEL.val(lptim2sel as u32)
+                + CCIPR1::SPI1SEL.val(spi1sel as u32)
+                + CCIPR1::SPI2SEL.val(spi2sel as u32)
+                + CCIPR1::UART4SEL.val(uart4sel as u32)
+                + CCIPR1::UART5SEL.val(uart5sel as u32)
+                + CCIPR1::USART1SEL.val(usart1sel as u32)
+                + CCIPR1::USART3SEL.val(usart3sel as u32),
+        );
+
+        self.registers.ccipr2.modify(
+            CCIPR2::OCTOSPISEL.val(octospisel as u32)
+                + CCIPR2::RNGSEL.val(rngsel as u32)
+                + CCIPR2::SAESSEL.val(saessel as u32)
+                + CCIPR2::SAI1SEL.val(sai1sel as u32)
+                + CCIPR2::SDMMCSEL.val(sdmmcsel as u32),
+        );
+
+        self.registers.ccipr3.modify(
+            CCIPR3::ADCDACSEL.val(adcdacsel as u32)
+                + CCIPR3::ADF1SEL.val(adf1sel as u32)
+                + CCIPR3::DAC1SEL.val(dac1sel as u32)
+                + CCIPR3::I2C3SEL.val(i2c3sel as u32)
+                + CCIPR3::LPTIM1SEL.val(lptim1sel as u32)
+                + CCIPR3::LPUART1SEL.val(lpuart1sel as u32)
+                + CCIPR3::SPI3SEL.val(spi3sel as u32),
+        );
+    }
+
+    // Enable clock routing to various peripherals
+    pub fn enable_dma1(&self) {
+        self.registers.ahb1enr.modify(AHB1ENR::GPDMA1EN::SET);
+    }
+    pub fn enable_gpioa(&self) {
+        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOAEN::SET);
+    }
+    pub fn enable_gpiob(&self) {
+        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOBEN::SET);
+    }
+    pub fn enable_gpioc(&self) {
+        self.registers.ahb2enr1.modify(AHB2ENR1::GPIOCEN::SET);
+    }
+    pub fn enable_usart1(&self) {
+        self.registers.apb2enr.modify(APB2ENR::USART1EN::SET);
+    }
+    pub fn enable_tim2(&self) {
+        self.registers.apb1enr1.modify(APB1ENR1::TIM2EN::SET);
+    }
+    pub fn enable_tim3(&self) {
+        self.registers.apb1enr1.modify(APB1ENR1::TIM3EN::SET);
+    }
+    pub fn enable_syscfg(&self) {
+        self.registers.apb3enr.modify(APB3ENR::SYSCFGEN::SET);
+    }
+    pub fn enable_pwr(&self) {
+        self.registers.ahb3enr.modify(AHB3ENR::PWREN::SET);
+    }
     pub fn enable_adc1(&self) {
         self.registers.ahb2enr1.modify(AHB2ENR1::ADC12EN::SET);
     }
-
+    pub fn enable_dac1(&self) {
+        self.registers.ahb3enr.modify(AHB3ENR::DAC1EN::SET);
+    }
+    pub fn enable_hash(&self) {
+        self.registers.ahb2enr1.modify(AHB2ENR1::HASHEN::SET);
+    }
     pub fn enable_trng(&self) {
         self.registers.ahb2enr1.modify(AHB2ENR1::TRNGEN::SET);
     }
 
-    pub fn set_usart1_source_pclk(&self) {
-        self.registers.ccipr1.modify(CCIPR1::USART1SEL::PCLK);
+    /// Get the effective frequency for PCLK (and PCLK used for timers) from an input frequency and prescaler
+    // For timers, the hardware automatically multiplies PCLK by 2 if the prescaler (divider) is not 1
+    fn calc_pclk<D>(hclk: Hertz, ppre: D) -> (Hertz, Hertz)
+    where
+        Hertz: core::ops::Div<D, Output = Hertz>,
+    {
+        let pclk = hclk / ppre;
+        let pclk_tim = if hclk == pclk { pclk } else { pclk * 2u32 };
+        (pclk, pclk_tim)
     }
 
-    pub fn set_adcdacsel_source_hsi16(&self) {
-        self.registers.ccipr3.modify(CCIPR3::ADCDACSEL::HSI16);
+    /// Convert `MsiRange` to its effective frequency
+    // Adapted from embassy-rs/embassy/embassy-stm32/src/rcc/u5.rs
+    fn msirange_to_hertz(range: MsiRange) -> Hertz {
+        match range {
+            MsiRange::Range48mhz => Hertz(48_000_000),
+            MsiRange::Range24mhz => Hertz(24_000_000),
+            MsiRange::Range16mhz => Hertz(16_000_000),
+            MsiRange::Range12mhz => Hertz(12_000_000),
+            MsiRange::Range4mhz => Hertz(4_000_000),
+            MsiRange::Range2mhz => Hertz(2_000_000),
+            MsiRange::Range133mhz => Hertz(1_330_000),
+            MsiRange::Range1mhz => Hertz(1_000_000),
+            MsiRange::Range3072mhz => Hertz(3_072_000),
+            MsiRange::Range1536mhz => Hertz(1_536_000),
+            MsiRange::Range1024mhz => Hertz(1_024_000),
+            MsiRange::Range768khz => Hertz(768_000),
+            MsiRange::Range400khz => Hertz(400_000),
+            MsiRange::Range200khz => Hertz(200_000),
+            MsiRange::Range133khz => Hertz(133_000),
+            MsiRange::Range100khz => Hertz(100_000),
+        }
     }
+}
 
-    pub fn enable_dac1(&self) {
-        self.registers.ahb3enr.modify(AHB3ENR::DAC1EN::SET);
-    }
+/// Used internally: taken by `Rcc::change_pll_enable` and `Rcc::init_pll`
+#[derive(Clone, Copy)]
+enum PllInstance {
+    Pll1 = 0,
+    Pll2 = 1,
+    Pll3 = 2,
+}
 
-    pub fn enable_hash(&self) {
-        self.registers.ahb2enr1.modify(AHB2ENR1::HASHEN::SET);
-    }
+/// Used internally: returned by `Rcc::init_pll`, used in `Rcc::init`
+#[derive(Default)]
+struct PllOutput {
+    pub p: Option<Hertz>,
+    pub q: Option<Hertz>,
+    pub r: Option<Hertz>,
 }

--- a/chips/stm32u5xx/src/rcc/config.rs
+++ b/chips/stm32u5xx/src/rcc/config.rs
@@ -1,0 +1,168 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+// Adapted from embassy-rs/embassy/embassy-stm32/src/rcc/u5.rs
+
+use super::hertz::Hertz;
+use super::{
+    Rcc,
+    values::{
+        AHBPrescaler, APBPrescaler, Adcdacsel, Adfsel, Dacsel, Fdcansel, I2c3sel, I2csel, Iclksel,
+        Lptim2sel, Lptimsel, Lpusartsel, MsiRange, Octospisel, PllDiv, PllMul, PllPreDiv,
+        PllSource, Rngsel, Rtcsel, Saessel, Saisel, Sdmmcsel, Spi1sel, Spi2sel, Spi3sel, Sysclk,
+        Usart1sel, Usartsel,
+    },
+};
+use crate::pwr::VoltageScale;
+
+#[derive(Copy, Clone)]
+pub struct RccConfig {
+    /// The voltage range influences the maximum clock frequencies for different parts of the device
+    ///
+    /// In particular, system clocks exceeding 110 MHz require `RANGE1`, and system clocks exceeding
+    /// 55 MHz require at least `RANGE2`
+    ///
+    /// See RM0456 § 10.5.4 for a general overview and § 11.4.10 for clock source frequency limits
+    pub voltage_range: VoltageScale,
+
+    // Base clock sources
+    pub msis: Option<MsiRange>,
+    pub msik: Option<MsiRange>,
+    pub hsi: bool,
+    pub hse: Option<Hse>,
+    pub hsi48: bool,
+
+    // PLL
+    pub pll1: Option<Pll>,
+    pub pll2: Option<Pll>,
+    pub pll3: Option<Pll>,
+
+    // SYSCLK, buses
+    pub sys: Sysclk,
+    pub ahb_pre: AHBPrescaler,
+    pub apb1_pre: APBPrescaler,
+    pub apb2_pre: APBPrescaler,
+    pub apb3_pre: APBPrescaler,
+
+    // Per-peripheral kernel clock selection muxes
+    pub mux: ClockMuxConfig,
+}
+
+/// Configuration for peripheral clock sources
+#[derive(Copy, Clone, Default)]
+pub struct ClockMuxConfig {
+    pub rtcsel: Rtcsel,
+    pub fdcan1sel: Fdcansel,
+    pub i2c1sel: I2csel,
+    pub i2c2sel: I2csel,
+    pub i2c4sel: I2csel,
+    pub iclksel: Iclksel,
+    pub lptim2sel: Lptim2sel,
+    pub spi1sel: Spi1sel,
+    pub spi2sel: Spi2sel,
+    pub uart4sel: Usartsel,
+    pub uart5sel: Usartsel,
+    pub usart1sel: Usart1sel,
+    pub usart3sel: Usartsel,
+    pub octospisel: Octospisel,
+    pub rngsel: Rngsel,
+    pub saessel: Saessel,
+    pub sai1sel: Saisel,
+    pub sdmmcsel: Sdmmcsel,
+    pub adcdacsel: Adcdacsel,
+    pub adf1sel: Adfsel,
+    pub dac1sel: Dacsel,
+    pub i2c3sel: I2c3sel,
+    pub lptim1sel: Lptimsel,
+    pub lpuart1sel: Lpusartsel,
+    pub spi3sel: Spi3sel,
+}
+impl ClockMuxConfig {
+    pub(crate) fn init(&self, rcc: &Rcc) {
+        rcc.set_clock_sources(
+            // BDCR
+            self.rtcsel,
+            // CCIPR1
+            self.fdcan1sel,
+            self.i2c1sel,
+            self.i2c2sel,
+            self.i2c4sel,
+            self.iclksel,
+            self.lptim2sel,
+            self.spi1sel,
+            self.spi2sel,
+            self.uart4sel,
+            self.uart5sel,
+            self.usart1sel,
+            self.usart3sel,
+            // CCIPR2
+            self.octospisel,
+            self.rngsel,
+            self.saessel,
+            self.sai1sel,
+            self.sdmmcsel,
+            // CCIPR3
+            self.adcdacsel,
+            self.adf1sel,
+            self.dac1sel,
+            self.i2c3sel,
+            self.lptim1sel,
+            self.lpuart1sel,
+            self.spi3sel,
+        );
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Hse {
+    pub freq: Hertz,
+    pub mode: HseMode,
+}
+
+#[derive(Copy, Clone)]
+pub enum HseMode {
+    /// Crystal/ceramic oscillator (HSEBYP=0)
+    Oscillator,
+    /// External analog clock (low swing) (HSEBYP=1, HSEEXT=0)
+    Bypass,
+    /// External digital clock (full swing) (HSEBYP=1, HSEEXT=1)
+    BypassDigital,
+}
+
+#[derive(Clone, Copy)]
+pub struct Pll {
+    /// The clock source for the PLL.
+    pub source: PllSource,
+    /// The PLL pre-divider.
+    ///
+    /// The clock speed of the `source` divided by `m` must be between 4 and 16 MHz.
+    pub prediv: PllPreDiv,
+    /// The PLL multiplier.
+    ///
+    /// The multiplied clock – `source` divided by `m` times `n` – must be between 128 and 544
+    /// MHz. The upper limit may be lower depending on the `Config { voltage_range }`.
+    pub mul: PllMul,
+    /// The divider for the P output.
+    ///
+    /// The P output is one of several options
+    /// that can be used to feed the SAI/MDF/ADF Clock mux's.
+    pub divp: Option<PllDiv>,
+    /// The divider for the Q output.
+    ///
+    /// The Q ouput is one of severals options that can be used to feed the 48MHz clocks
+    /// and the OCTOSPI clock. It may also be used on the MDF/ADF clock mux's.
+    pub divq: Option<PllDiv>,
+    /// The divider for the R output.
+    ///
+    /// When used to drive the system clock, `source` divided by `m` times `n` divided by `r`
+    /// must not exceed 160 MHz. System clocks above 55 MHz require a non-default
+    /// `Config { voltage_range }`.
+    pub divr: Option<PllDiv>,
+}
+
+pub struct PllInput {
+    pub hsi: Option<Hertz>,
+    pub hse: Option<Hertz>,
+    pub msi: Option<Hertz>,
+}

--- a/chips/stm32u5xx/src/rcc/hertz.rs
+++ b/chips/stm32u5xx/src/rcc/hertz.rs
@@ -1,0 +1,118 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+// Adapted from embassy-rs/embassy/embassy-stm32/src/time.rs
+
+use core::fmt::Display;
+use core::ops::{Div, Mul};
+
+/// Hertz
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Default)]
+pub struct Hertz(pub u32);
+
+impl Display for Hertz {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} Hz", self.0)
+    }
+}
+
+impl Hertz {
+    /// Create a `Hertz` from the given hertz.
+    pub const fn hz(hertz: u32) -> Self {
+        Self(hertz)
+    }
+
+    /// Create a `Hertz` from the given kilohertz.
+    pub const fn khz(kilohertz: u32) -> Self {
+        Self(kilohertz * 1_000)
+    }
+
+    /// Create a `Hertz` from the given megahertz.
+    pub const fn mhz(megahertz: u32) -> Self {
+        Self(megahertz * 1_000_000)
+    }
+}
+
+pub(crate) trait Prescaler {
+    fn num(&self) -> u32;
+    fn denom(&self) -> u32;
+}
+
+impl<T: Prescaler> Div<T> for Hertz {
+    type Output = Hertz;
+    fn div(self, rhs: T) -> Self::Output {
+        self * rhs.denom() / rhs.num()
+    }
+}
+
+impl<T: Prescaler> Mul<T> for Hertz {
+    type Output = Hertz;
+    fn mul(self, rhs: T) -> Self::Output {
+        self * rhs.num() / rhs.denom()
+    }
+}
+
+/// This is a convenience shortcut for [`Hertz::hz`]
+pub const fn hz(hertz: u32) -> Hertz {
+    Hertz::hz(hertz)
+}
+
+/// This is a convenience shortcut for [`Hertz::khz`]
+pub const fn khz(kilohertz: u32) -> Hertz {
+    Hertz::khz(kilohertz)
+}
+
+/// This is a convenience shortcut for [`Hertz::mhz`]
+pub const fn mhz(megahertz: u32) -> Hertz {
+    Hertz::mhz(megahertz)
+}
+
+impl Mul<u32> for Hertz {
+    type Output = Hertz;
+    fn mul(self, rhs: u32) -> Self::Output {
+        Hertz(self.0 * rhs)
+    }
+}
+
+impl Div<u32> for Hertz {
+    type Output = Hertz;
+    fn div(self, rhs: u32) -> Self::Output {
+        Hertz(self.0 / rhs)
+    }
+}
+
+impl Mul<u16> for Hertz {
+    type Output = Hertz;
+    fn mul(self, rhs: u16) -> Self::Output {
+        self * (rhs as u32)
+    }
+}
+
+impl Div<u16> for Hertz {
+    type Output = Hertz;
+    fn div(self, rhs: u16) -> Self::Output {
+        self / (rhs as u32)
+    }
+}
+
+impl Mul<u8> for Hertz {
+    type Output = Hertz;
+    fn mul(self, rhs: u8) -> Self::Output {
+        self * (rhs as u32)
+    }
+}
+
+impl Div<u8> for Hertz {
+    type Output = Hertz;
+    fn div(self, rhs: u8) -> Self::Output {
+        self / (rhs as u32)
+    }
+}
+
+impl Div<Hertz> for Hertz {
+    type Output = u32;
+    fn div(self, rhs: Hertz) -> Self::Output {
+        self.0 / rhs.0
+    }
+}

--- a/chips/stm32u5xx/src/rcc/values.rs
+++ b/chips/stm32u5xx/src/rcc/values.rs
@@ -1,0 +1,1154 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+// Adapted from embassy-rs/stm32-data-generated/stm32-metapac/src/peripherals/rcc_u5.rs
+
+use super::hertz;
+
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum MsiRange {
+    /// range 0 around 48 MHz
+    Range48mhz = 0x0,
+    /// range 1 around 24 MHz
+    Range24mhz = 0x01,
+    /// range 2 around 16 MHz
+    Range16mhz = 0x02,
+    /// range 3 around 12 MHz
+    Range12mhz = 0x03,
+    /// range 4 around 4 MHz (reset value)
+    Range4mhz = 0x04,
+    /// range 5 around 2 MHz
+    Range2mhz = 0x05,
+    /// range 6 around 1.33 MHz
+    Range133mhz = 0x06,
+    /// range 7 around 1 MHz
+    Range1mhz = 0x07,
+    /// range 8 around 3.072 MHz
+    Range3072mhz = 0x08,
+    /// range 9 around 1.536 MHz
+    Range1536mhz = 0x09,
+    /// range 10 around 1.024 MHz
+    Range1024mhz = 0x0a,
+    /// range 11 around 768 kHz
+    Range768khz = 0x0b,
+    /// range 12 around 400 kHz
+    Range400khz = 0x0c,
+    /// range 13 around 200 kHz
+    Range200khz = 0x0d,
+    /// range 14 around 133 kHz
+    Range133khz = 0x0e,
+    /// range 15 around 100 kHz
+    Range100khz = 0x0f,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum PllSource {
+    /// No clock sent to PLL
+    Disable = 0x0,
+    /// MSIS clock selected as PLL clock entry
+    Msis = 0x01,
+    /// HSI clock selected as PLL clock entry
+    Hsi = 0x02,
+    /// HSE clock selected as PLL clock entry
+    Hse = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum Sysclk {
+    /// MSIS selected as system clock
+    Msis = 0x0,
+    /// HSI selected as system clock
+    Hsi = 0x01,
+    /// HSE selected as system clock
+    Hse = 0x02,
+    /// PLL pll1_r_ck selected as system clock
+    Pll1R = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum PllPreDiv {
+    Div1 = 0x0,
+    Div2 = 0x01,
+    Div3 = 0x02,
+    Div4 = 0x03,
+    Div5 = 0x04,
+    Div6 = 0x05,
+    Div7 = 0x06,
+    Div8 = 0x07,
+    Div9 = 0x08,
+    Div10 = 0x09,
+    Div11 = 0x0a,
+    Div12 = 0x0b,
+    Div13 = 0x0c,
+    Div14 = 0x0d,
+    Div15 = 0x0e,
+    Div16 = 0x0f,
+}
+impl hertz::Prescaler for PllPreDiv {
+    fn num(&self) -> u32 {
+        *self as u32 + 1
+    }
+    fn denom(&self) -> u32 {
+        1
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum PllMul {
+    Mul4 = 0x03,
+    Mul5 = 0x04,
+    Mul6 = 0x05,
+    Mul7 = 0x06,
+    Mul8 = 0x07,
+    Mul9 = 0x08,
+    Mul10 = 0x09,
+    Mul11 = 0x0a,
+    Mul12 = 0x0b,
+    Mul13 = 0x0c,
+    Mul14 = 0x0d,
+    Mul15 = 0x0e,
+    Mul16 = 0x0f,
+    Mul17 = 0x10,
+    Mul18 = 0x11,
+    Mul19 = 0x12,
+    Mul20 = 0x13,
+    Mul21 = 0x14,
+    Mul22 = 0x15,
+    Mul23 = 0x16,
+    Mul24 = 0x17,
+    Mul25 = 0x18,
+    Mul26 = 0x19,
+    Mul27 = 0x1a,
+    Mul28 = 0x1b,
+    Mul29 = 0x1c,
+    Mul30 = 0x1d,
+    Mul31 = 0x1e,
+    Mul32 = 0x1f,
+    Mul33 = 0x20,
+    Mul34 = 0x21,
+    Mul35 = 0x22,
+    Mul36 = 0x23,
+    Mul37 = 0x24,
+    Mul38 = 0x25,
+    Mul39 = 0x26,
+    Mul40 = 0x27,
+    Mul41 = 0x28,
+    Mul42 = 0x29,
+    Mul43 = 0x2a,
+    Mul44 = 0x2b,
+    Mul45 = 0x2c,
+    Mul46 = 0x2d,
+    Mul47 = 0x2e,
+    Mul48 = 0x2f,
+    Mul49 = 0x30,
+    Mul50 = 0x31,
+    Mul51 = 0x32,
+    Mul52 = 0x33,
+    Mul53 = 0x34,
+    Mul54 = 0x35,
+    Mul55 = 0x36,
+    Mul56 = 0x37,
+    Mul57 = 0x38,
+    Mul58 = 0x39,
+    Mul59 = 0x3a,
+    Mul60 = 0x3b,
+    Mul61 = 0x3c,
+    Mul62 = 0x3d,
+    Mul63 = 0x3e,
+    Mul64 = 0x3f,
+    Mul65 = 0x40,
+    Mul66 = 0x41,
+    Mul67 = 0x42,
+    Mul68 = 0x43,
+    Mul69 = 0x44,
+    Mul70 = 0x45,
+    Mul71 = 0x46,
+    Mul72 = 0x47,
+    Mul73 = 0x48,
+    Mul74 = 0x49,
+    Mul75 = 0x4a,
+    Mul76 = 0x4b,
+    Mul77 = 0x4c,
+    Mul78 = 0x4d,
+    Mul79 = 0x4e,
+    Mul80 = 0x4f,
+    Mul81 = 0x50,
+    Mul82 = 0x51,
+    Mul83 = 0x52,
+    Mul84 = 0x53,
+    Mul85 = 0x54,
+    Mul86 = 0x55,
+    Mul87 = 0x56,
+    Mul88 = 0x57,
+    Mul89 = 0x58,
+    Mul90 = 0x59,
+    Mul91 = 0x5a,
+    Mul92 = 0x5b,
+    Mul93 = 0x5c,
+    Mul94 = 0x5d,
+    Mul95 = 0x5e,
+    Mul96 = 0x5f,
+    Mul97 = 0x60,
+    Mul98 = 0x61,
+    Mul99 = 0x62,
+    Mul100 = 0x63,
+    Mul101 = 0x64,
+    Mul102 = 0x65,
+    Mul103 = 0x66,
+    Mul104 = 0x67,
+    Mul105 = 0x68,
+    Mul106 = 0x69,
+    Mul107 = 0x6a,
+    Mul108 = 0x6b,
+    Mul109 = 0x6c,
+    Mul110 = 0x6d,
+    Mul111 = 0x6e,
+    Mul112 = 0x6f,
+    Mul113 = 0x70,
+    Mul114 = 0x71,
+    Mul115 = 0x72,
+    Mul116 = 0x73,
+    Mul117 = 0x74,
+    Mul118 = 0x75,
+    Mul119 = 0x76,
+    Mul120 = 0x77,
+    Mul121 = 0x78,
+    Mul122 = 0x79,
+    Mul123 = 0x7a,
+    Mul124 = 0x7b,
+    Mul125 = 0x7c,
+    Mul126 = 0x7d,
+    Mul127 = 0x7e,
+    Mul128 = 0x7f,
+    Mul129 = 0x80,
+    Mul130 = 0x81,
+    Mul131 = 0x82,
+    Mul132 = 0x83,
+    Mul133 = 0x84,
+    Mul134 = 0x85,
+    Mul135 = 0x86,
+    Mul136 = 0x87,
+    Mul137 = 0x88,
+    Mul138 = 0x89,
+    Mul139 = 0x8a,
+    Mul140 = 0x8b,
+    Mul141 = 0x8c,
+    Mul142 = 0x8d,
+    Mul143 = 0x8e,
+    Mul144 = 0x8f,
+    Mul145 = 0x90,
+    Mul146 = 0x91,
+    Mul147 = 0x92,
+    Mul148 = 0x93,
+    Mul149 = 0x94,
+    Mul150 = 0x95,
+    Mul151 = 0x96,
+    Mul152 = 0x97,
+    Mul153 = 0x98,
+    Mul154 = 0x99,
+    Mul155 = 0x9a,
+    Mul156 = 0x9b,
+    Mul157 = 0x9c,
+    Mul158 = 0x9d,
+    Mul159 = 0x9e,
+    Mul160 = 0x9f,
+    Mul161 = 0xa0,
+    Mul162 = 0xa1,
+    Mul163 = 0xa2,
+    Mul164 = 0xa3,
+    Mul165 = 0xa4,
+    Mul166 = 0xa5,
+    Mul167 = 0xa6,
+    Mul168 = 0xa7,
+    Mul169 = 0xa8,
+    Mul170 = 0xa9,
+    Mul171 = 0xaa,
+    Mul172 = 0xab,
+    Mul173 = 0xac,
+    Mul174 = 0xad,
+    Mul175 = 0xae,
+    Mul176 = 0xaf,
+    Mul177 = 0xb0,
+    Mul178 = 0xb1,
+    Mul179 = 0xb2,
+    Mul180 = 0xb3,
+    Mul181 = 0xb4,
+    Mul182 = 0xb5,
+    Mul183 = 0xb6,
+    Mul184 = 0xb7,
+    Mul185 = 0xb8,
+    Mul186 = 0xb9,
+    Mul187 = 0xba,
+    Mul188 = 0xbb,
+    Mul189 = 0xbc,
+    Mul190 = 0xbd,
+    Mul191 = 0xbe,
+    Mul192 = 0xbf,
+    Mul193 = 0xc0,
+    Mul194 = 0xc1,
+    Mul195 = 0xc2,
+    Mul196 = 0xc3,
+    Mul197 = 0xc4,
+    Mul198 = 0xc5,
+    Mul199 = 0xc6,
+    Mul200 = 0xc7,
+    Mul201 = 0xc8,
+    Mul202 = 0xc9,
+    Mul203 = 0xca,
+    Mul204 = 0xcb,
+    Mul205 = 0xcc,
+    Mul206 = 0xcd,
+    Mul207 = 0xce,
+    Mul208 = 0xcf,
+    Mul209 = 0xd0,
+    Mul210 = 0xd1,
+    Mul211 = 0xd2,
+    Mul212 = 0xd3,
+    Mul213 = 0xd4,
+    Mul214 = 0xd5,
+    Mul215 = 0xd6,
+    Mul216 = 0xd7,
+    Mul217 = 0xd8,
+    Mul218 = 0xd9,
+    Mul219 = 0xda,
+    Mul220 = 0xdb,
+    Mul221 = 0xdc,
+    Mul222 = 0xdd,
+    Mul223 = 0xde,
+    Mul224 = 0xdf,
+    Mul225 = 0xe0,
+    Mul226 = 0xe1,
+    Mul227 = 0xe2,
+    Mul228 = 0xe3,
+    Mul229 = 0xe4,
+    Mul230 = 0xe5,
+    Mul231 = 0xe6,
+    Mul232 = 0xe7,
+    Mul233 = 0xe8,
+    Mul234 = 0xe9,
+    Mul235 = 0xea,
+    Mul236 = 0xeb,
+    Mul237 = 0xec,
+    Mul238 = 0xed,
+    Mul239 = 0xee,
+    Mul240 = 0xef,
+    Mul241 = 0xf0,
+    Mul242 = 0xf1,
+    Mul243 = 0xf2,
+    Mul244 = 0xf3,
+    Mul245 = 0xf4,
+    Mul246 = 0xf5,
+    Mul247 = 0xf6,
+    Mul248 = 0xf7,
+    Mul249 = 0xf8,
+    Mul250 = 0xf9,
+    Mul251 = 0xfa,
+    Mul252 = 0xfb,
+    Mul253 = 0xfc,
+    Mul254 = 0xfd,
+    Mul255 = 0xfe,
+    Mul256 = 0xff,
+    Mul257 = 0x0100,
+    Mul258 = 0x0101,
+    Mul259 = 0x0102,
+    Mul260 = 0x0103,
+    Mul261 = 0x0104,
+    Mul262 = 0x0105,
+    Mul263 = 0x0106,
+    Mul264 = 0x0107,
+    Mul265 = 0x0108,
+    Mul266 = 0x0109,
+    Mul267 = 0x010a,
+    Mul268 = 0x010b,
+    Mul269 = 0x010c,
+    Mul270 = 0x010d,
+    Mul271 = 0x010e,
+    Mul272 = 0x010f,
+    Mul273 = 0x0110,
+    Mul274 = 0x0111,
+    Mul275 = 0x0112,
+    Mul276 = 0x0113,
+    Mul277 = 0x0114,
+    Mul278 = 0x0115,
+    Mul279 = 0x0116,
+    Mul280 = 0x0117,
+    Mul281 = 0x0118,
+    Mul282 = 0x0119,
+    Mul283 = 0x011a,
+    Mul284 = 0x011b,
+    Mul285 = 0x011c,
+    Mul286 = 0x011d,
+    Mul287 = 0x011e,
+    Mul288 = 0x011f,
+    Mul289 = 0x0120,
+    Mul290 = 0x0121,
+    Mul291 = 0x0122,
+    Mul292 = 0x0123,
+    Mul293 = 0x0124,
+    Mul294 = 0x0125,
+    Mul295 = 0x0126,
+    Mul296 = 0x0127,
+    Mul297 = 0x0128,
+    Mul298 = 0x0129,
+    Mul299 = 0x012a,
+    Mul300 = 0x012b,
+    Mul301 = 0x012c,
+    Mul302 = 0x012d,
+    Mul303 = 0x012e,
+    Mul304 = 0x012f,
+    Mul305 = 0x0130,
+    Mul306 = 0x0131,
+    Mul307 = 0x0132,
+    Mul308 = 0x0133,
+    Mul309 = 0x0134,
+    Mul310 = 0x0135,
+    Mul311 = 0x0136,
+    Mul312 = 0x0137,
+    Mul313 = 0x0138,
+    Mul314 = 0x0139,
+    Mul315 = 0x013a,
+    Mul316 = 0x013b,
+    Mul317 = 0x013c,
+    Mul318 = 0x013d,
+    Mul319 = 0x013e,
+    Mul320 = 0x013f,
+    Mul321 = 0x0140,
+    Mul322 = 0x0141,
+    Mul323 = 0x0142,
+    Mul324 = 0x0143,
+    Mul325 = 0x0144,
+    Mul326 = 0x0145,
+    Mul327 = 0x0146,
+    Mul328 = 0x0147,
+    Mul329 = 0x0148,
+    Mul330 = 0x0149,
+    Mul331 = 0x014a,
+    Mul332 = 0x014b,
+    Mul333 = 0x014c,
+    Mul334 = 0x014d,
+    Mul335 = 0x014e,
+    Mul336 = 0x014f,
+    Mul337 = 0x0150,
+    Mul338 = 0x0151,
+    Mul339 = 0x0152,
+    Mul340 = 0x0153,
+    Mul341 = 0x0154,
+    Mul342 = 0x0155,
+    Mul343 = 0x0156,
+    Mul344 = 0x0157,
+    Mul345 = 0x0158,
+    Mul346 = 0x0159,
+    Mul347 = 0x015a,
+    Mul348 = 0x015b,
+    Mul349 = 0x015c,
+    Mul350 = 0x015d,
+    Mul351 = 0x015e,
+    Mul352 = 0x015f,
+    Mul353 = 0x0160,
+    Mul354 = 0x0161,
+    Mul355 = 0x0162,
+    Mul356 = 0x0163,
+    Mul357 = 0x0164,
+    Mul358 = 0x0165,
+    Mul359 = 0x0166,
+    Mul360 = 0x0167,
+    Mul361 = 0x0168,
+    Mul362 = 0x0169,
+    Mul363 = 0x016a,
+    Mul364 = 0x016b,
+    Mul365 = 0x016c,
+    Mul366 = 0x016d,
+    Mul367 = 0x016e,
+    Mul368 = 0x016f,
+    Mul369 = 0x0170,
+    Mul370 = 0x0171,
+    Mul371 = 0x0172,
+    Mul372 = 0x0173,
+    Mul373 = 0x0174,
+    Mul374 = 0x0175,
+    Mul375 = 0x0176,
+    Mul376 = 0x0177,
+    Mul377 = 0x0178,
+    Mul378 = 0x0179,
+    Mul379 = 0x017a,
+    Mul380 = 0x017b,
+    Mul381 = 0x017c,
+    Mul382 = 0x017d,
+    Mul383 = 0x017e,
+    Mul384 = 0x017f,
+    Mul385 = 0x0180,
+    Mul386 = 0x0181,
+    Mul387 = 0x0182,
+    Mul388 = 0x0183,
+    Mul389 = 0x0184,
+    Mul390 = 0x0185,
+    Mul391 = 0x0186,
+    Mul392 = 0x0187,
+    Mul393 = 0x0188,
+    Mul394 = 0x0189,
+    Mul395 = 0x018a,
+    Mul396 = 0x018b,
+    Mul397 = 0x018c,
+    Mul398 = 0x018d,
+    Mul399 = 0x018e,
+    Mul400 = 0x018f,
+    Mul401 = 0x0190,
+    Mul402 = 0x0191,
+    Mul403 = 0x0192,
+    Mul404 = 0x0193,
+    Mul405 = 0x0194,
+    Mul406 = 0x0195,
+    Mul407 = 0x0196,
+    Mul408 = 0x0197,
+    Mul409 = 0x0198,
+    Mul410 = 0x0199,
+    Mul411 = 0x019a,
+    Mul412 = 0x019b,
+    Mul413 = 0x019c,
+    Mul414 = 0x019d,
+    Mul415 = 0x019e,
+    Mul416 = 0x019f,
+    Mul417 = 0x01a0,
+    Mul418 = 0x01a1,
+    Mul419 = 0x01a2,
+    Mul420 = 0x01a3,
+    Mul421 = 0x01a4,
+    Mul422 = 0x01a5,
+    Mul423 = 0x01a6,
+    Mul424 = 0x01a7,
+    Mul425 = 0x01a8,
+    Mul426 = 0x01a9,
+    Mul427 = 0x01aa,
+    Mul428 = 0x01ab,
+    Mul429 = 0x01ac,
+    Mul430 = 0x01ad,
+    Mul431 = 0x01ae,
+    Mul432 = 0x01af,
+    Mul433 = 0x01b0,
+    Mul434 = 0x01b1,
+    Mul435 = 0x01b2,
+    Mul436 = 0x01b3,
+    Mul437 = 0x01b4,
+    Mul438 = 0x01b5,
+    Mul439 = 0x01b6,
+    Mul440 = 0x01b7,
+    Mul441 = 0x01b8,
+    Mul442 = 0x01b9,
+    Mul443 = 0x01ba,
+    Mul444 = 0x01bb,
+    Mul445 = 0x01bc,
+    Mul446 = 0x01bd,
+    Mul447 = 0x01be,
+    Mul448 = 0x01bf,
+    Mul449 = 0x01c0,
+    Mul450 = 0x01c1,
+    Mul451 = 0x01c2,
+    Mul452 = 0x01c3,
+    Mul453 = 0x01c4,
+    Mul454 = 0x01c5,
+    Mul455 = 0x01c6,
+    Mul456 = 0x01c7,
+    Mul457 = 0x01c8,
+    Mul458 = 0x01c9,
+    Mul459 = 0x01ca,
+    Mul460 = 0x01cb,
+    Mul461 = 0x01cc,
+    Mul462 = 0x01cd,
+    Mul463 = 0x01ce,
+    Mul464 = 0x01cf,
+    Mul465 = 0x01d0,
+    Mul466 = 0x01d1,
+    Mul467 = 0x01d2,
+    Mul468 = 0x01d3,
+    Mul469 = 0x01d4,
+    Mul470 = 0x01d5,
+    Mul471 = 0x01d6,
+    Mul472 = 0x01d7,
+    Mul473 = 0x01d8,
+    Mul474 = 0x01d9,
+    Mul475 = 0x01da,
+    Mul476 = 0x01db,
+    Mul477 = 0x01dc,
+    Mul478 = 0x01dd,
+    Mul479 = 0x01de,
+    Mul480 = 0x01df,
+    Mul481 = 0x01e0,
+    Mul482 = 0x01e1,
+    Mul483 = 0x01e2,
+    Mul484 = 0x01e3,
+    Mul485 = 0x01e4,
+    Mul486 = 0x01e5,
+    Mul487 = 0x01e6,
+    Mul488 = 0x01e7,
+    Mul489 = 0x01e8,
+    Mul490 = 0x01e9,
+    Mul491 = 0x01ea,
+    Mul492 = 0x01eb,
+    Mul493 = 0x01ec,
+    Mul494 = 0x01ed,
+    Mul495 = 0x01ee,
+    Mul496 = 0x01ef,
+    Mul497 = 0x01f0,
+    Mul498 = 0x01f1,
+    Mul499 = 0x01f2,
+    Mul500 = 0x01f3,
+    Mul501 = 0x01f4,
+    Mul502 = 0x01f5,
+    Mul503 = 0x01f6,
+    Mul504 = 0x01f7,
+    Mul505 = 0x01f8,
+    Mul506 = 0x01f9,
+    Mul507 = 0x01fa,
+    Mul508 = 0x01fb,
+    Mul509 = 0x01fc,
+    Mul510 = 0x01fd,
+    Mul511 = 0x01fe,
+    Mul512 = 0x01ff,
+}
+impl hertz::Prescaler for PllMul {
+    fn num(&self) -> u32 {
+        *self as u32 + 1
+    }
+    fn denom(&self) -> u32 {
+        1
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum PllDiv {
+    Div1 = 0x0,
+    Div2 = 0x01,
+    Div3 = 0x02,
+    Div4 = 0x03,
+    Div5 = 0x04,
+    Div6 = 0x05,
+    Div7 = 0x06,
+    Div8 = 0x07,
+    Div9 = 0x08,
+    Div10 = 0x09,
+    Div11 = 0x0a,
+    Div12 = 0x0b,
+    Div13 = 0x0c,
+    Div14 = 0x0d,
+    Div15 = 0x0e,
+    Div16 = 0x0f,
+    Div17 = 0x10,
+    Div18 = 0x11,
+    Div19 = 0x12,
+    Div20 = 0x13,
+    Div21 = 0x14,
+    Div22 = 0x15,
+    Div23 = 0x16,
+    Div24 = 0x17,
+    Div25 = 0x18,
+    Div26 = 0x19,
+    Div27 = 0x1a,
+    Div28 = 0x1b,
+    Div29 = 0x1c,
+    Div30 = 0x1d,
+    Div31 = 0x1e,
+    Div32 = 0x1f,
+    Div33 = 0x20,
+    Div34 = 0x21,
+    Div35 = 0x22,
+    Div36 = 0x23,
+    Div37 = 0x24,
+    Div38 = 0x25,
+    Div39 = 0x26,
+    Div40 = 0x27,
+    Div41 = 0x28,
+    Div42 = 0x29,
+    Div43 = 0x2a,
+    Div44 = 0x2b,
+    Div45 = 0x2c,
+    Div46 = 0x2d,
+    Div47 = 0x2e,
+    Div48 = 0x2f,
+    Div49 = 0x30,
+    Div50 = 0x31,
+    Div51 = 0x32,
+    Div52 = 0x33,
+    Div53 = 0x34,
+    Div54 = 0x35,
+    Div55 = 0x36,
+    Div56 = 0x37,
+    Div57 = 0x38,
+    Div58 = 0x39,
+    Div59 = 0x3a,
+    Div60 = 0x3b,
+    Div61 = 0x3c,
+    Div62 = 0x3d,
+    Div63 = 0x3e,
+    Div64 = 0x3f,
+    Div65 = 0x40,
+    Div66 = 0x41,
+    Div67 = 0x42,
+    Div68 = 0x43,
+    Div69 = 0x44,
+    Div70 = 0x45,
+    Div71 = 0x46,
+    Div72 = 0x47,
+    Div73 = 0x48,
+    Div74 = 0x49,
+    Div75 = 0x4a,
+    Div76 = 0x4b,
+    Div77 = 0x4c,
+    Div78 = 0x4d,
+    Div79 = 0x4e,
+    Div80 = 0x4f,
+    Div81 = 0x50,
+    Div82 = 0x51,
+    Div83 = 0x52,
+    Div84 = 0x53,
+    Div85 = 0x54,
+    Div86 = 0x55,
+    Div87 = 0x56,
+    Div88 = 0x57,
+    Div89 = 0x58,
+    Div90 = 0x59,
+    Div91 = 0x5a,
+    Div92 = 0x5b,
+    Div93 = 0x5c,
+    Div94 = 0x5d,
+    Div95 = 0x5e,
+    Div96 = 0x5f,
+    Div97 = 0x60,
+    Div98 = 0x61,
+    Div99 = 0x62,
+    Div100 = 0x63,
+    Div101 = 0x64,
+    Div102 = 0x65,
+    Div103 = 0x66,
+    Div104 = 0x67,
+    Div105 = 0x68,
+    Div106 = 0x69,
+    Div107 = 0x6a,
+    Div108 = 0x6b,
+    Div109 = 0x6c,
+    Div110 = 0x6d,
+    Div111 = 0x6e,
+    Div112 = 0x6f,
+    Div113 = 0x70,
+    Div114 = 0x71,
+    Div115 = 0x72,
+    Div116 = 0x73,
+    Div117 = 0x74,
+    Div118 = 0x75,
+    Div119 = 0x76,
+    Div120 = 0x77,
+    Div121 = 0x78,
+    Div122 = 0x79,
+    Div123 = 0x7a,
+    Div124 = 0x7b,
+    Div125 = 0x7c,
+    Div126 = 0x7d,
+    Div127 = 0x7e,
+    Div128 = 0x7f,
+}
+impl hertz::Prescaler for PllDiv {
+    fn num(&self) -> u32 {
+        *self as u32 + 1
+    }
+    fn denom(&self) -> u32 {
+        1
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum AHBPrescaler {
+    /// SYSCLK not divided
+    Div1 = 0x0,
+    /// SYSCLK divided by 2
+    Div2 = 0x08,
+    /// SYSCLK divided by 4
+    Div4 = 0x09,
+    /// SYSCLK divided by 8
+    Div8 = 0x0a,
+    /// SYSCLK divided by 16
+    Div16 = 0x0b,
+    /// SYSCLK divided by 64
+    Div64 = 0x0c,
+    /// SYSCLK divided by 128
+    Div128 = 0x0d,
+    /// SYSCLK divided by 256
+    Div256 = 0x0e,
+    /// SYSCLK divided by 512
+    Div512 = 0x0f,
+}
+impl hertz::Prescaler for AHBPrescaler {
+    fn num(&self) -> u32 {
+        match *self {
+            Self::Div1 => 1,
+            Self::Div2 => 2,
+            Self::Div4 => 4,
+            Self::Div8 => 8,
+            Self::Div16 => 16,
+            Self::Div64 => 64,
+            Self::Div128 => 128,
+            Self::Div256 => 256,
+            Self::Div512 => 512,
+        }
+    }
+    fn denom(&self) -> u32 {
+        1
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum APBPrescaler {
+    /// HCLK not divided
+    Div1 = 0x0,
+    /// HCLK divided by 2
+    Div2 = 0x04,
+    /// HCLK divided by 4
+    Div4 = 0x05,
+    /// HCLK divided by 8
+    Div8 = 0x06,
+    /// HCLK divided by 16
+    Div16 = 0x07,
+}
+impl hertz::Prescaler for APBPrescaler {
+    fn num(&self) -> u32 {
+        match *self {
+            Self::Div1 => 1,
+            Self::Div2 => 2,
+            Self::Div4 => 4,
+            Self::Div8 => 8,
+            Self::Div16 => 16,
+        }
+    }
+    fn denom(&self) -> u32 {
+        1
+    }
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Rtcsel {
+    /// No clock selected
+    #[default]
+    Disable = 0x0,
+    /// LSE oscillator clock selected
+    Lse = 0x01,
+    /// LSI oscillator clock selected
+    Lsi = 0x02,
+    /// HSE oscillator clock divided by 32 selected
+    Hse = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Fdcansel {
+    /// HSE clock selected
+    #[default]
+    Hse = 0x0,
+    /// PLL1 Q (pll1_q_ck) selected
+    Pll1Q = 0x01,
+    /// PLL2 P (pll2_p_ck) selected
+    Pll2P = 0x02,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum I2csel {
+    /// PCLK1 selected
+    #[default]
+    Pclk1 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// MSIK selected
+    Msik = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Iclksel {
+    /// HSI48 clock selected
+    #[default]
+    Hsi48 = 0x0,
+    /// PLL2 Q (pll2_q_ck) selected
+    Pll2Q = 0x01,
+    /// PLL1 Q (pll1_q_ck) selected
+    Pll1Q = 0x02,
+    /// MSIK clock selected
+    Msik = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Lptim2sel {
+    /// PCLK1 selected
+    #[default]
+    Pclk1 = 0x0,
+    /// LSI selected
+    Lsi = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// LSE selected
+    Lse = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Spi1sel {
+    /// PCLK2 selected
+    #[default]
+    Pclk2 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// MSIK selected
+    Msik = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Spi2sel {
+    /// PCLK2 selected
+    #[default]
+    Pclk1 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// MSIK selected
+    Msik = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Usartsel {
+    /// PCLK1 selected
+    #[default]
+    Pclk1 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// LSE selected
+    Lse = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Usart1sel {
+    /// PCLK2 selected
+    #[default]
+    Pclk2 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// LSE selected
+    Lse = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Octospisel {
+    /// SYSCLK selected
+    #[default]
+    Sys = 0x0,
+    /// MSIK selected
+    Msik = 0x01,
+    /// PLL1 Q (pll1_q_ck) selected, can be up to 200 MHz
+    Pll1Q = 0x02,
+    /// PLL2 Q (pll2_q_ck) selected, can be up to 200 MHz
+    Pll2Q = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Rngsel {
+    /// HSI48 selected
+    #[default]
+    Hsi48 = 0x0,
+    /// HSI48 / 2 selected, can be used in Range 4
+    Hsi48Div2 = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Saessel {
+    /// SHSI selected
+    #[default]
+    Shsi = 0x0,
+    /// SHSI / 2 selected, can be used in Range 4
+    ShsiDiv2 = 0x01,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Saisel {
+    /// PLL2 P (pll2_p_ck) selected
+    #[default]
+    Pll2P = 0x0,
+    /// PLL3 P (pll3_p_ck) selected
+    Pll3P = 0x01,
+    /// PLL1 P (pll1_p_ck) selected
+    Pll1P = 0x02,
+    /// input pin AUDIOCLK selected
+    Audioclk = 0x03,
+    /// HSI clock selected
+    Hsi = 0x04,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Sdmmcsel {
+    /// ICLK clock selected
+    #[default]
+    Iclk = 0x0,
+    /// PLL1 P (pll1_p_ck) selected, in case higher than 48 MHz is needed (for SDR50 mode)
+    Pll1P = 0x01,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Adcdacsel {
+    /// HCLK clock selected
+    #[default]
+    Hclk1 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// PLL2 R (pll2_r_ck) selected
+    Pll2R = 0x02,
+    /// HSE clock selected
+    Hse = 0x03,
+    /// HSI clock selected
+    Hsi = 0x04,
+    /// MSIK clock selected
+    Msik = 0x05,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Adfsel {
+    /// HCLK selected
+    #[default]
+    Hclk3 = 0x0,
+    /// PLL1 P (pll1_p_ck) selected
+    Pll1P = 0x01,
+    /// PLL3 Q (pll3_q_ck) selected
+    Pll3Q = 0x02,
+    /// input pin AUDIOCLK selected
+    Audioclk = 0x03,
+    /// MSIK clock selected
+    Msik = 0x04,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Dacsel {
+    /// LSE selected
+    #[default]
+    Lse = 0x0,
+    /// LSI selected
+    Lsi = 0x01,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum I2c3sel {
+    /// PCLK3 selected
+    #[default]
+    Pclk3 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// MSIK selected
+    Msik = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Lptimsel {
+    /// MSIK selected
+    #[default]
+    Msik = 0x0,
+    /// LSI selected
+    Lsi = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// LSE selected
+    Lse = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Lpusartsel {
+    /// PCLK3 selected
+    #[default]
+    Pclk3 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// LSE selected
+    Lse = 0x03,
+    /// MSIK selected
+    Msik = 0x04,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Spi3sel {
+    /// PCLK2 selected
+    #[default]
+    Pclk3 = 0x0,
+    /// SYSCLK selected
+    Sys = 0x01,
+    /// HSI selected
+    Hsi = 0x02,
+    /// MSIK selected
+    Msik = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum Pllrge {
+    /// PLL2 input (ref2_ck) clock range frequency between 4 and 8 MHz
+    #[default]
+    Freq4to8mhz = 0x0,
+    /// PLL2 input (ref2_ck) clock range frequency between 8 and 16 MHz
+    Freq8to16mhz = 0x03,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
+pub enum PllMboost {
+    /// division by 1 (bypass)
+    #[default]
+    Div1 = 0x0,
+    /// division by 2
+    Div2 = 0x01,
+    /// division by 4
+    Div4 = 0x02,
+    /// division by 6
+    Div6 = 0x03,
+    /// division by 8
+    Div8 = 0x04,
+    /// division by 10
+    Div10 = 0x05,
+    /// division by 12
+    Div12 = 0x06,
+    /// division by 14
+    Div14 = 0x07,
+    /// division by 16
+    Div16 = 0x08,
+}

--- a/chips/stm32u5xx/src/rng.rs
+++ b/chips/stm32u5xx/src/rng.rs
@@ -76,7 +76,7 @@ register_bitfields![u32,
         HTCFG OFFSET(0) NUMBITS(32) []
     ]
 ];
-pub const RNG_BASE: StaticRef<RngRegisters> =
+const RNG_BASE: StaticRef<RngRegisters> =
     unsafe { StaticRef::new(0x520C0800 as *const RngRegisters) };
 
 /// Iterator that retreives the full entropy outputs provided by the RNG peripheral
@@ -118,9 +118,9 @@ pub struct Trng<'a, const CR: u32, const HTCR: u32, const NSCR: u32> {
 impl<const CR_CFG: u32, const HTCR_CFG: u32, const NSCR_CFG: u32>
     Trng<'_, CR_CFG, HTCR_CFG, NSCR_CFG>
 {
-    pub fn new(base: StaticRef<RngRegisters>) -> Self {
+    pub fn new() -> Self {
         Self {
-            registers: base,
+            registers: RNG_BASE,
             client: OptionalCell::empty(),
             entropy_needed: Cell::new(false),
             deferred_call: DeferredCall::new(),

--- a/chips/stm32u5xx/src/tim.rs
+++ b/chips/stm32u5xx/src/tim.rs
@@ -11,7 +11,10 @@ use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields, register_structs};
 
-use crate::gpio::{Mode, Pin};
+use crate::{
+    gpio::{Mode, Pin},
+    rcc::Clocks,
+};
 
 register_structs! {
     pub TimRegisters {
@@ -66,7 +69,7 @@ register_structs! {
     }
 }
 
-pub const TIM2_BASE: StaticRef<TimRegisters> =
+const TIM2_BASE: StaticRef<TimRegisters> =
     unsafe { StaticRef::new(0x50000000 as *const TimRegisters) };
 
 register_bitfields![u32,
@@ -404,25 +407,22 @@ register_bitfields![u32,
 /// timing while remaining power-efficient.
 pub struct Tim2<'a> {
     registers: StaticRef<TimRegisters>,
-    enable_clock: fn(),
+    clocks: OptionalCell<Clocks>,
     client: OptionalCell<&'a dyn time::AlarmClient>,
 }
 
 impl<'a> Tim2<'a> {
     /// Creates a new instance of the driver.
-    ///
-    /// - `base`: The StaticRef pointing to the MMIO base address of the peripheral.
-    /// - `enable_clock`: (For Timers) A callback function to power on the peripheral via RCC.
-    pub const fn new(base: StaticRef<TimRegisters>, enable_clock: fn()) -> Tim2<'a> {
+    pub const fn new() -> Tim2<'a> {
         Tim2 {
-            registers: base,
-            enable_clock,
+            registers: TIM2_BASE,
+            clocks: OptionalCell::empty(),
             client: OptionalCell::empty(),
         }
     }
 
-    fn enable_clock(&self) {
-        (self.enable_clock)();
+    pub fn set_clocks(&self, clocks: Clocks) {
+        self.clocks.set(clocks);
     }
 
     /// Core interrupt handler for the peripheral.
@@ -442,19 +442,24 @@ impl<'a> Tim2<'a> {
 
     /// Initializes and starts the timer hardware.
     ///
-    /// This sets the prescaler to 124 (converting the 4MHz clock to 32kHz)
-    /// and enables the 32-bit free-running counter.
+    /// This sets the prescaler to convert PCLK1 to 32kHz and enables the 32-bit free-running counter.
     pub fn start(&self) {
-        self.enable_clock();
+        // Get the frequency of the clock that feeds TIM2
+        let input_freq = self.clocks.get().unwrap().pclk1_tim;
 
-        // 1. Set the value
-        self.registers.psc.write(PSC::PSC.val(124));
+        // Determine the required prescaler to achieve 32kHz
+        let prescaler_value = input_freq / 32_000_u32;
 
-        // 2. Force the hardware to load the value NOW
-        // On STM32, the PSC is buffered. By setting the UG bit in EGR,
+        // Set the prescaler; the value used by hardware is [PSC + 1], so 1 must be subtracted
+        self.registers
+            .psc
+            .write(PSC::PSC.val(prescaler_value.0 - 1));
+
+        // Force the hardware to load the value NOW
+        // On STM32, the PSC is buffered.
         self.registers.egr.write(EGR::UG::SET);
 
-        // 3. Clear the status flag caused by the manual update
+        // Clear the status flag caused by the manual update
         self.registers.sr.modify(SR::UIF::CLEAR);
 
         self.registers.arr.write(ARR::ARR.val(0xFFFFFFFF));
@@ -524,62 +529,39 @@ impl<'a> time::Alarm<'a> for Tim2<'a> {
 // This driver implements the Tock PWM HIL using the 16-bit general-purpose TIM3 timer.
 // It works by making the timer count from 0 to a specified value and toggling the pin high/low
 
-pub enum ClockSource {
-    /// high-speed internal 16 MHz RC oscillator clock
-    Hsi16,
-    /// multi-speed internal RC oscillator clock , composed of four
-    /// base oscillators (48 MHz, 4 MHz, 3.072 MHz, 400 kHz)
-    Msis(usize),
-    /// high-speed external crystal or clock, from 4 to 50 MHz
-    Hse(usize),
-    /// PLL1 output, depends on PLL configuration (input, multiplier,dividers)
-    Pll1(usize),
-}
-
-impl ClockSource {
-    /// MSIS is selected as the system clock on startup after a reset. Configured at 4MHz
-    pub const RESET_DEFAULT: ClockSource = ClockSource::Msis(4_000_000);
-
-    pub fn as_hz(&self) -> usize {
-        match self {
-            ClockSource::Hsi16 => 16_000_000,
-            ClockSource::Msis(hz) => *hz,
-            ClockSource::Hse(hz) => *hz,
-            ClockSource::Pll1(hz) => *hz,
-        }
-    }
-}
-
-pub const TIM3_BASE: StaticRef<TimRegisters> =
+const TIM3_BASE: StaticRef<TimRegisters> =
     unsafe { StaticRef::new(0x50000400 as *const TimRegisters) };
 
 pub struct Pwm<'a> {
     // Base address for the TIM3 registers
     registers: StaticRef<TimRegisters>,
-    // The clock source
-    timer_clock: ClockSource,
-    // Function to enable the clock for the timer
-    enable_clock: fn(),
+    // All effective clock frequencies
+    clocks: OptionalCell<Clocks>,
     // Needed so the struct can carry 'a lifetime because of type Pin = Pin<'a>
     _phantom: core::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> Pwm<'a> {
-    pub const fn new(
-        base: StaticRef<TimRegisters>,
-        enable_clock: fn(),
-        timer_clock: ClockSource,
-    ) -> Pwm<'a> {
+    pub const fn new() -> Pwm<'a> {
         Pwm {
-            registers: base,
-            timer_clock,
-            enable_clock,
+            registers: TIM3_BASE,
+            clocks: OptionalCell::empty(),
             _phantom: core::marker::PhantomData,
         }
     }
-    fn enable_clock(&self) {
-        (self.enable_clock)();
+
+    pub fn set_clocks(&self, clocks: Clocks) {
+        self.clocks.set(clocks);
     }
+
+    fn get_maximum_frequency_hz(&self) -> usize {
+        self.clocks.get().unwrap().pclk1_tim.0 as usize
+    }
+
+    fn get_maximum_duty_cycle(&self) -> usize {
+        u16::MAX as usize + 1
+    }
+
     // Switches the pin to alternate function mode and sets the alternate function to AF2 (TIM3_CH1)
     fn configure_pin(&self, pin: &Pin) {
         pin.set_mode(Mode::AlternateFunction);
@@ -593,31 +575,33 @@ impl<'a> Pwm<'a> {
         duty_cycle: usize,
         max_duty_cycle: usize,
     ) -> Result<(), ErrorCode> {
-        self.enable_clock();
-
         if frequency_hz == 0 {
             return self.stop_pwm(pin);
         }
 
-        if frequency_hz > self.timer_clock.as_hz() {
+        // Get the frequency of the clock that feeds TIM3
+        let input_hz = self.clocks.get().unwrap().pclk1_tim.0 as usize;
+
+        if frequency_hz > input_hz {
             return Err(ErrorCode::INVAL);
         }
 
         if duty_cycle > max_duty_cycle {
             return Err(ErrorCode::INVAL);
         }
+
         // Prevent overflow in the ARR register
-        if self.timer_clock.as_hz() / frequency_hz > 65535 {
+        if input_hz / frequency_hz > 65535 {
             return Err(ErrorCode::INVAL);
         }
 
         self.configure_pin(pin);
 
-        //We keep the prescaler 0 for maximum resolution
+        // We keep the prescaler 0 for maximum resolution
         let prescaler = 0;
         // Arr_value is the value that the timer counts to before resetting , it determines the frequency of the signal.
         // We derive it from Frequency = TimerClock / ((PSC + 1) * (ARR + 1))
-        let arr_value = (self.timer_clock.as_hz() / frequency_hz) - 1;
+        let arr_value = (input_hz / frequency_hz) - 1;
         // CCR = ARR * (duty_cycle / max_duty_cycle)
         // This is the value at which the output pin will be toggled. This dictates the duty cycle of the signal.
         // For example if Arr = 100 and Ccr = 25 , the output will be high for 25 ticks and low for 75 ticks, giving a duty cycle of 25%
@@ -664,11 +648,11 @@ impl<'a> hil::pwm::Pwm for Pwm<'a> {
     }
 
     fn get_maximum_frequency_hz(&self) -> usize {
-        self.timer_clock.as_hz()
+        self.get_maximum_frequency_hz()
     }
 
     fn get_maximum_duty_cycle(&self) -> usize {
-        u16::MAX as usize + 1
+        self.get_maximum_duty_cycle()
     }
 }
 
@@ -695,9 +679,9 @@ impl hil::pwm::PwmPin for PwmPin<'_> {
         self.pwm.stop_pwm(self.pin)
     }
     fn get_maximum_frequency_hz(&self) -> usize {
-        self.pwm.timer_clock.as_hz()
+        self.pwm.get_maximum_frequency_hz()
     }
     fn get_maximum_duty_cycle(&self) -> usize {
-        u16::MAX as usize + 1
+        self.pwm.get_maximum_duty_cycle()
     }
 }

--- a/chips/stm32u5xx/src/usart.rs
+++ b/chips/stm32u5xx/src/usart.rs
@@ -14,10 +14,13 @@ use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::dma_slice::DmaSubSliceMut;
 use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::leasable_buffer::SubSliceMut;
+use kernel::utilities::registers::FieldValue;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     ReadOnly, ReadWrite, WriteOnly, register_bitfields, register_structs,
 };
+
+use crate::rcc::Clocks;
 
 register_structs! {
     pub UsartRegisters {
@@ -66,7 +69,9 @@ register_bitfields![u32,
         /// Transmission complete interrupt enable
         TCIE    OFFSET(6)   NUMBITS(1) [],
         /// TXE interrupt enable
-        TXEIE   OFFSET(7)   NUMBITS(1) []
+        TXEIE   OFFSET(7)   NUMBITS(1) [],
+        /// Oversampling mode
+        OVER8   OFFSET(15)  NUMBITS(1) []
     ],
     pub CR2 [
         /// STOP bits
@@ -146,7 +151,20 @@ register_bitfields![u32,
     ],
     pub PRESC [
         /// Clock prescaler
-        PRESCALER OFFSET(0) NUMBITS(4) []
+        PRESCALER OFFSET(0) NUMBITS(4) [
+            DIV1 = 0,
+            DIV2 = 1,
+            DIV4 = 2,
+            DIV6 = 3,
+            DIV8 = 4,
+            DIV10 = 5,
+            DIV12 = 6,
+            DIV16 = 7,
+            DIV32 = 8,
+            DIV64 = 9,
+            DIV128 = 10,
+            DIV256 = 11
+        ]
     ]
 ];
 
@@ -158,6 +176,7 @@ register_bitfields![u32,
 /// captured correctly.
 pub struct Usart<'a> {
     pub registers: StaticRef<UsartRegisters>,
+    clocks: OptionalCell<Clocks>,
     dma: OptionalCell<&'a Dma>,
     dma_channel_tx: Cell<Option<ChannelId>>,
     dma_channel_rx: Cell<Option<ChannelId>>,
@@ -176,6 +195,7 @@ impl<'a> Usart<'a> {
     pub fn new(base: StaticRef<UsartRegisters>) -> Self {
         Self {
             registers: base,
+            clocks: OptionalCell::empty(),
             dma: OptionalCell::empty(),
             dma_channel_tx: Cell::new(None),
             dma_channel_rx: Cell::new(None),
@@ -188,6 +208,88 @@ impl<'a> Usart<'a> {
             deferred_call: DeferredCall::new(),
             tx_deferred: Cell::new(false),
             rx_deferred: Cell::new(false),
+        }
+    }
+
+    pub fn set_clocks(&self, clocks: Clocks) {
+        self.clocks.set(clocks);
+    }
+
+    // Adapted from embassy-rs/embassy/embassy-stm32/src/uart/mod.rs
+    fn calculate_brr(baud: u32, pclk: u32, presc: u32, mul: u32) -> u32 {
+        // The calculation to be done to get the BRR is `mul * pclk / presc / baud`
+        // To do this in 32-bit only we can't multiply `mul` and `pclk`
+        let clock = pclk / presc;
+
+        // The mul is applied as the last operation to prevent overflow
+        let brr = clock / baud * mul;
+
+        // The BRR calculation will be a bit off because of integer rounding.
+        // Because we multiplied our inaccuracy with mul, our rounding now needs to be in proportion to mul.
+        let rounding = ((clock % baud) * mul + (baud / 2)) / baud;
+
+        brr + rounding
+    }
+
+    // Adapted from embassy-rs/embassy/embassy-stm32/src/uart/mod.rs
+    fn find_and_set_baudrate(&self, baudrate: u32) -> Result<(), BaudrateError> {
+        const DIVS: [(u16, FieldValue<u32, PRESC::Register>); 12] = [
+            (1, PRESC::PRESCALER::DIV1),
+            (2, PRESC::PRESCALER::DIV2),
+            (4, PRESC::PRESCALER::DIV4),
+            (6, PRESC::PRESCALER::DIV6),
+            (8, PRESC::PRESCALER::DIV8),
+            (10, PRESC::PRESCALER::DIV10),
+            (12, PRESC::PRESCALER::DIV12),
+            (16, PRESC::PRESCALER::DIV16),
+            (32, PRESC::PRESCALER::DIV32),
+            (64, PRESC::PRESCALER::DIV64),
+            (128, PRESC::PRESCALER::DIV128),
+            (256, PRESC::PRESCALER::DIV256),
+        ];
+
+        // USART1 is fed by clock PCKL2
+        let kernel_clock = self.clocks.get().unwrap().pclk2;
+
+        let (mul, brr_min, brr_max) = (1, 0x10, 0x1_0000);
+
+        let mut found_brr = false;
+        let mut over8 = false;
+
+        for &(presc, presc_fields_value) in &DIVS {
+            let brr = Self::calculate_brr(baudrate, kernel_clock.0, presc as u32, mul);
+
+            if brr < brr_min {
+                if brr * 2 >= brr_min {
+                    over8 = true;
+
+                    self.registers
+                        .brr
+                        .write(BRR::BRR.val(((brr << 1) & !0xF) | (brr & 0x07)));
+
+                    self.registers.presc.write(presc_fields_value);
+
+                    found_brr = true;
+                    break;
+                }
+
+                return Err(BaudrateError::TooHigh);
+            }
+
+            if brr < brr_max {
+                self.registers.brr.write(BRR::BRR.val(brr));
+                self.registers.presc.write(presc_fields_value);
+                found_brr = true;
+                break;
+            }
+        }
+
+        self.registers.cr1.modify(CR1::OVER8.val(over8 as u32));
+
+        if found_brr {
+            Ok(())
+        } else {
+            Err(BaudrateError::TooLow)
         }
     }
 
@@ -288,6 +390,11 @@ impl<'a> Usart<'a> {
             regs.cr3.modify(CR3::DMAT::SET);
         }
     }
+}
+
+enum BaudrateError {
+    TooHigh,
+    TooLow,
 }
 
 impl DeferredCallClient for Usart<'_> {
@@ -412,11 +519,20 @@ impl<'a> uart::Transmit<'a> for Usart<'a> {
 }
 
 impl uart::Configure for Usart<'_> {
-    fn configure(&self, _params: uart::Parameters) -> Result<(), kernel::ErrorCode> {
+    fn configure(&self, params: uart::Parameters) -> Result<(), kernel::ErrorCode> {
+        // The clock frequencies must be known at this point
+        if self.clocks.get().is_none() {
+            return Err(kernel::ErrorCode::FAIL);
+        }
+
         let regs = &*self.registers;
         regs.cr1.modify(CR1::UE::CLEAR);
-        regs.presc.write(PRESC::PRESCALER.val(0));
-        regs.brr.write(BRR::BRR.val(35));
+
+        // Set the baud rate
+        if self.find_and_set_baudrate(params.baud_rate).is_err() {
+            return Err(kernel::ErrorCode::INVAL);
+        }
+
         regs.icr.write(
             ICR::TCCF::SET + ICR::ORECF::SET + ICR::NECF::SET + ICR::FECF::SET + ICR::PECF::SET,
         );


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the ability to configure the clock tree for STM32U5xx chips. Peripherals which must calculate prescalers (TIM2, USART1, etc.) now have access to the current clock frequencies, computed at chip initialization.

Some other (unrelated) files have also been changed, in an attempt to make the code more consistent, like adding/changing comments and removing unnecessary constructor arguments for peripherals.

Note: this branch has been rebased with the upstream master at the time of writing. My changes consist of a single (squashed) commit.


### Testing Strategy

This pull request was tested by flashing the kernel to a NUCLEO-U545RE-Q board and observing the behavior of the libtock-c apps `blink` and `c_hello` while changing the clock configuration.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
